### PR TITLE
fix: zwave-terminal [L] set-lifeline key was dead

### DIFF
--- a/utils/zwave-terminal/main.cpp
+++ b/utils/zwave-terminal/main.cpp
@@ -1744,7 +1744,7 @@ auto main() -> int
             {
                 handleGetConfiguration(*proxy, sessionCounter);
             }
-            else if (key == 'l' || key == 'L')
+            else if (key == 'l')
             {
                 handleListNodes(*proxy);
             }


### PR DESCRIPTION
The key dispatch matched `key == 'l' || key == 'L'` for **list-nodes** *before* the `key == 'L'` **set-lifeline** branch, so pressing `L` always listed nodes and the menu's advertised "[L] Set lifeline" action was unreachable.

Fix: list-nodes now matches only `'l'`, so `'L'` falls through to `handleSetLifeline`.

Pre-existing bug (predates the recent terminal work); spotted while adding the CC-report keys in #74. One-line change; builds + clang-format + clang-tidy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)