### PR TITLE
feat: pending-queue + wake-up visibility in zwave-terminal (#75)

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -1585,6 +1585,21 @@ dbus:
       triggered_by:
         event: WakeUpCycleComplete
 
+    - name: PendingCommandEnqueued
+      params:
+        - { name: nodeId,   dbus: y }
+        - { name: sequence, dbus: u }
+        - { name: priority, dbus: y }
+      triggered_by:
+        event: PendingCommandEnqueued
+
+    - name: PendingCommandsDrained
+      params:
+        - { name: nodeId, dbus: y }
+        - { name: count,  dbus: u }
+      triggered_by:
+        event: PendingCommandsDrained
+
     - name: InclusionLifelineSet
       params:
         - { name: nodeId, dbus: y }

--- a/TODO.md
+++ b/TODO.md
@@ -143,7 +143,7 @@ Implementation order (each shippable independently):
 ### Display
 
 - [x] **Surface typed CC reports in the activity pane** — [#74](https://github.com/Assar63/zwaved/issues/74): terminal now subscribes to `BatteryReport` / `ConfigurationReport` / `ManufacturerSpecificReport` / `NodeVersionReport` / `ZWavePlusInfoReport` / `WakeUpIntervalReport` / `WakeUpNotification` (on top of the existing SwitchBinary/Multilevel), each rendered as a readable one-liner. New GET keys: `[b]` Battery, `[v]` Version, `[m]` Mfr-specific, `[z]` Z-Wave+, `[7]` Configuration. Undecoded CCs still fall back to the raw `ApplicationCommand` hex dump.
-- [ ] [Pending-queue + wake-up orchestration visibility](https://github.com/Assar63/zwaved/issues/75) — show `PendingCommandEnqueued` / `PendingCommandsDrained` / `WakeUpCycleComplete` / `WakeUpNotification`.
+- [x] **Pending-queue + wake-up orchestration visibility** — [#75](https://github.com/Assar63/zwaved/issues/75): terminal shows `PendingCommandEnqueued` / `PendingCommandsDrained` / `WakeUpCycleComplete` / `WakeUpNotification` in the activity pane. `PendingCommandEnqueued` / `PendingCommandsDrained` were bus-only — added their D-Bus signals to the manifest so the terminal (and any D-Bus client) can observe them. Per-node "pending count" column deferred (needs a `peek` D-Bus accessor — noted as a future follow-up).
 - [ ] [DaemonError banner](https://github.com/Assar63/zwaved/issues/76) — consume the retained `DaemonError` feed; colour by severity.
 
 - [ ] [Help window (zwave-terminal)](https://github.com/Assar63/zwaved/issues/41)

--- a/utils/zwave-terminal/main.cpp
+++ b/utils/zwave-terminal/main.cpp
@@ -590,6 +590,43 @@ auto registerSignalHandlers(sdbus::IProxy& proxy) -> void
                 logLine("WakeUpNotification node=" + std::to_string(static_cast<unsigned>(sourceNodeId)) + " (awake)");
             });
 
+    // Pending-command queue + wake-up orchestration traffic (#75): the
+    // daemon stashes commands for sleeping nodes and drains them on
+    // wake-up. These are observability signals only — the queue is fed
+    // indirectly by Set/Get calls, not driven from here.
+    proxy.uponSignal("PendingCommandEnqueued")
+        .onInterface(IFACE_NAME)
+        .call(
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus signal
+            [](std::uint8_t nodeId, std::uint32_t sequence, std::uint8_t priority) -> void
+            {
+                std::ostringstream stream;
+                stream << "PendingCommandEnqueued node=" << static_cast<unsigned>(nodeId) << " seq=" << sequence
+                       << " priority=" << static_cast<unsigned>(priority);
+                logLine(stream.str());
+            });
+
+    proxy.uponSignal("PendingCommandsDrained")
+        .onInterface(IFACE_NAME)
+        .call(
+            [](std::uint8_t nodeId, std::uint32_t count) -> void
+            {
+                std::ostringstream stream;
+                stream << "PendingCommandsDrained node=" << static_cast<unsigned>(nodeId) << " count=" << count;
+                logLine(stream.str());
+            });
+
+    proxy.uponSignal("WakeUpCycleComplete")
+        .onInterface(IFACE_NAME)
+        .call(
+            [](std::uint8_t nodeId, std::uint32_t drainedCount) -> void
+            {
+                std::ostringstream stream;
+                stream << "WakeUpCycleComplete node=" << static_cast<unsigned>(nodeId) << " drained=" << drainedCount
+                       << " (back to sleep)";
+                logLine(stream.str());
+            });
+
     proxy.uponSignal("ApplicationCommand")
         .onInterface(IFACE_NAME)
         .call(


### PR DESCRIPTION
Closes #75. Part of the terminal-parity epic #73.

The terminal now surfaces the pending-command-queue + wake-up orchestration traffic in the activity pane:

| Signal | Example line |
|--------|--------------|
| `PendingCommandEnqueued` | `PendingCommandEnqueued node=7 seq=42 priority=100` |
| `PendingCommandsDrained` | `PendingCommandsDrained node=7 count=3` |
| `WakeUpCycleComplete` | `WakeUpCycleComplete node=7 drained=3 (back to sleep)` |

(`WakeUpNotification` was already shown — added in #74.)

### Daemon change

`PendingCommandEnqueued` / `PendingCommandsDrained` were **bus-only** events (`subscribers: [external-api]`, but no D-Bus signal), so no client could observe them. Added their signal entries to `InterfaceManifest.yml`; the codegen emits the registration + emission subscriber. Observability only — the queue is fed indirectly by Set/Get, never driven from the terminal.

### Deferred

The optional per-node "pending count" column needs a `peek`/diagnostic D-Bus accessor that doesn't exist yet — left for a follow-up.

### Verification

Full suite **204/204** green; `clang-format` + `clang-tidy` clean (terminal **and** daemon, since the generated signal code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)