### PR TITLE
fix: SensorMultilevel test — GCC build (span from braced-init-list)

### DIFF
--- a/tests/SensorMultilevel_test.cpp
+++ b/tests/SensorMultilevel_test.cpp
@@ -74,9 +74,11 @@ TEST(SensorMultilevel, RejectsInvalidSizeAndMalformed)
     EXPECT_FALSE(SensorMultilevel::decodeReport(report(0x01, 0x03, {0x00, 0x01, 0x02})).has_value());
     // truncated: flag says size 4 but only 2 value bytes present
     EXPECT_FALSE(SensorMultilevel::decodeReport(report(0x01, 0x04, {0x00, 0x01})).has_value());
-    // wrong command class
-    EXPECT_FALSE(SensorMultilevel::decodeReport({0x80, 0x05, 0x01, 0x22, 0x00, 0xD7}).has_value());
+    // wrong command class (build the vector explicitly: a braced-init-list
+    // doesn't implicitly convert to std::span under GCC).
+    const std::vector<std::uint8_t> wrongCc{0x80, 0x05, 0x01, 0x22, 0x00, 0xD7};
+    EXPECT_FALSE(SensorMultilevel::decodeReport(wrongCc).has_value());
     // wrong command byte (Get, not Report)
-    EXPECT_FALSE(
-        SensorMultilevel::decodeReport({SensorMultilevel::COMMAND_CLASS, 0x04, 0x01, 0x22, 0x00, 0xD7}).has_value());
+    const std::vector<std::uint8_t> wrongCmd{SensorMultilevel::COMMAND_CLASS, 0x04, 0x01, 0x22, 0x00, 0xD7};
+    EXPECT_FALSE(SensorMultilevel::decodeReport(wrongCmd).has_value());
 }


### PR DESCRIPTION
Unbreaks `build-and-test` (gnu) on master, broken by #96.

Two malformed-frame test cases passed a braced-init-list directly to `decodeReport(std::span<const std::uint8_t>)`. **clang accepts** that (materializes a temporary array); **GCC 15 rejects** it (`could not convert ... to std::span`), so the gnu CI build failed while llvm passed — and #96 merged with the red gnu check. Fixed by building the payloads as named `std::vector` first, like the suite's other cases.

Verified with a full `cmake --preset gnu && cmake --build && ctest` (210/210) this time — the gap was that I'd only built llvm + gnu-tidy locally, not a full gnu compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)