### PR TITLE
feat: Thermostat Mode (CC 0x40) set/get + typed report signal

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -480,6 +480,18 @@ events:
       - { name: previousValue, type: i32,  default: 0, doc: "raw; valid only when hasPrevious" }
       - { name: hasPrevious,   type: bool, default: false }
 
+  - name: ThermostatModeReport
+    category: transient
+    direction: { publishers: [cc-translator], subscribers: [external-api] }
+    doc: |
+      Typed Thermostat Mode (CC 0x40) Report. Republished by the
+      cc-translator from inbound ApplicationCommand frames whose ccData
+      parses as a Thermostat Mode Report. `mode`: 0 off, 1 heat, 2 cool,
+      3 auto, 6 fan only, 8 dry, … (raw byte; naming left to clients).
+    fields:
+      - { name: sourceNodeId, type: u8, default: 0 }
+      - { name: mode,         type: u8, default: 0 }
+
   - name: WakeUpIntervalReport
     category: transient
     direction: { publishers: [cc-translator], subscribers: [external-api] }
@@ -851,6 +863,23 @@ events:
       - { name: scale,      type: u8, default: 0 }
       - { name: callbackId, type: u8, default: 0 }
 
+  - name: SetThermostatModeCommand
+    category: command
+    direction: { publishers: [external-api], subscribers: [zwave-protocol] }
+    doc: "Set a node's thermostat mode (0 off, 1 heat, 2 cool, 3 auto, …)."
+    fields:
+      - { name: nodeId,     type: u8, default: 0 }
+      - { name: mode,       type: u8, default: 0 }
+      - { name: callbackId, type: u8, default: 0 }
+
+  - name: GetThermostatModeCommand
+    category: command
+    direction: { publishers: [external-api], subscribers: [zwave-protocol] }
+    doc: Query a node's current thermostat mode.
+    fields:
+      - { name: nodeId,     type: u8, default: 0 }
+      - { name: callbackId, type: u8, default: 0 }
+
   - name: GetBatteryCommand
     category: command
     direction: { publishers: [external-api], subscribers: [zwave-protocol] }
@@ -1219,6 +1248,21 @@ dbus:
         - { name: callbackId, dbus: y, cpp: u8 }
       action:
         publish: GetMeterCommand
+
+    - name: SetThermostatMode
+      params:
+        - { name: nodeId,     dbus: y, cpp: u8 }
+        - { name: mode,       dbus: y, cpp: u8 }
+        - { name: callbackId, dbus: y, cpp: u8 }
+      action:
+        publish: SetThermostatModeCommand
+
+    - name: GetThermostatMode
+      params:
+        - { name: nodeId,     dbus: y, cpp: u8 }
+        - { name: callbackId, dbus: y, cpp: u8 }
+      action:
+        publish: GetThermostatModeCommand
 
     - name: GetManufacturerSpecific
       params:
@@ -1713,6 +1757,13 @@ dbus:
       triggered_by:
         event: MeterReport
 
+    - name: ThermostatModeReport
+      params:
+        - { name: sourceNodeId, dbus: y }
+        - { name: mode,         dbus: y, doc: "0 off, 1 heat, 2 cool, 3 auto, 6 fan only, 8 dry, …" }
+      triggered_by:
+        event: ThermostatModeReport
+
     - name: ManufacturerSpecificReport
       params:
         - { name: sourceNodeId,   dbus: y }
@@ -2071,6 +2122,42 @@ modules:
           - { name: previousValue, type: i32,  doc: "raw signed previous value; valid iff hasPrevious" }
           - { name: hasPrevious,   type: bool, doc: "true iff deltaTime != 0 and previousValue present" }
 
+  - name: ThermostatMode
+    wire:
+      class_byte: 0x40
+      prefix: THERMOSTAT_MODE
+    description: |
+      HVAC operating mode. SET takes a single mode byte (the low 5 bits;
+      the high 3 bits are a v3 manufacturer-data length, sent as 0 here);
+      REPORT carries the current mode. mode: 0 off, 1 heat, 2 cool, 3 auto,
+      4 aux heat, 6 fan only, 7 furnace, 8 dry, 9 moist, 10 auto changeover,
+      11 energy-save heat, 12 energy-save cool, 13 away. The decoder returns
+      the raw byte and leaves naming to clients. First of the split
+      thermostat quartet (epic #23).
+    constants:
+      - { name: MODE_OFF,  value: 0x00 }
+      - { name: MODE_HEAT, value: 0x01 }
+      - { name: MODE_COOL, value: 0x02 }
+      - { name: MODE_AUTO, value: 0x03 }
+    commands:
+      - name: Set
+        wire:
+          byte: 0x01
+          payload:
+            - "mode"
+        encode_args:
+          - { name: mode, type: u8 }
+      - name: Get
+        wire:
+          byte: 0x02
+          payload: []
+        encode_args: []
+      - name: Report
+        wire:
+          byte: 0x03
+        decoded_struct:
+          - { name: mode, type: u8, doc: "0 off, 1 heat, 2 cool, 3 auto, 6 fan only, 8 dry, …" }
+
   - name: Configuration
     wire:
       class_byte: 0x70
@@ -2404,6 +2491,16 @@ translations:
       deltaTime:     decoded.deltaTime
       previousValue: decoded.previousValue
       hasPrevious:   decoded.hasPrevious
+
+  - publishes: ThermostatModeReport
+    triggered_by: ApplicationCommand
+    decode:
+      codec: ThermostatMode.decodeReport
+      input: ccData
+      on_none: skip
+    map:
+      sourceNodeId: event.sourceNodeId
+      mode:         decoded.mode
 
   - publishes: ManufacturerSpecificReport
     triggered_by: ApplicationCommand

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -568,6 +568,35 @@ the v4 dual-scale extension, `SUPPORTED_GET`/`REPORT`, and `RESET` are not.
 In the terminal, `[j]` prompts for node + scale, issues the Get, and reports
 render as `MeterReport node=5 electric 12.345 kWh (Δ3600s, prev 12.000)`.
 
+## 11h. Thermostat mode (CC 0x40)
+
+The Thermostat Mode Command Class sets/reads an HVAC unit's operating mode.
+It is the first CC of the thermostat quartet (Setpoint 0x43, Operating
+State 0x42, Fan Mode 0x44 follow). `SetThermostatMode(nodeId, mode,
+callbackId)` changes the mode; `GetThermostatMode(nodeId, callbackId)`
+queries it. The reply and any unsolicited Reports arrive as the typed
+`ThermostatModeReport(y y)` signal:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `sourceNodeId` | `y` | the reporting node |
+| `mode` | `y` | 0 off, 1 heat, 2 cool, 3 auto, 4 aux heat, 6 fan only, 8 dry, 10 auto changeover, 11 energy-save heat, 12 energy-save cool, 13 away |
+
+```bash
+# set node 5 to heat, then read it back
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 SetThermostatMode yyy 5 1 7
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 GetThermostatMode yy 5 8
+# → ThermostatModeReport y y  5 1   = node 5 heat
+```
+
+The decoder masks the mode byte's low 5 bits (the high 3 bits are a v3
+manufacturer-data-field count) and returns the raw mode; naming is left to
+clients. `SUPPORTED_GET`/`REPORT` are not implemented. In the terminal,
+`[0]` sets the mode and `[y]` gets it; reports render as
+`ThermostatModeReport node=5 mode=heat`.
+
 ## 12. Unsolicited node events
 
 When a node sends an unsolicited Command Class frame — most commonly a

--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@ Implementation order (each shippable independently):
 - [ ] [Color Switch (CC 0x33)](https://github.com/Assar63/zwaved/issues/21)
 - [ ] [Central Scene (CC 0x5B)](https://github.com/Assar63/zwaved/issues/22)
 - [ ] [epic: Thermostat HVAC quartet](https://github.com/Assar63/zwaved/issues/23) — split into per-CC subtasks (each an independent slice):
-  - [ ] [Thermostat Mode (CC 0x40)](https://github.com/Assar63/zwaved/issues/103)
+  - [x] **Thermostat Mode (CC `0x40`)** — [#103](https://github.com/Assar63/zwaved/issues/103): `SetThermostatMode(nodeId, mode, callbackId)` + `GetThermostatMode(nodeId, callbackId)` over D-Bus; generated `encodeSet`/`encodeGet`, hand-written `decodeReport` (masks the mode byte's low 5 bits — high 3 are a v3 manufacturer-data count). Republished by the cc-translator as the typed `ThermostatModeReport(y y)` signal. Terminal `[0]` sets / `[y]` gets, rendered with mode names. 5 codec unit tests. **Note:** terminal is now out of single-key bindings (only `[y]`/`[0]` were left) — the remaining quartet CCs need a submenu/rebinding scheme (follow-up under terminal epic #73). SUPPORTED_GET/REPORT deferred.
   - [ ] [Thermostat Setpoint (CC 0x43)](https://github.com/Assar63/zwaved/issues/104) — shares the precision/scale/size value codec with Sensor Multilevel (#17)
   - [ ] [Thermostat Operating State (CC 0x42)](https://github.com/Assar63/zwaved/issues/105) — read-only
   - [ ] [Thermostat Fan Mode (CC 0x44)](https://github.com/Assar63/zwaved/issues/106)

--- a/src/zwave-protocol/ProtocolThread.cpp
+++ b/src/zwave-protocol/ProtocolThread.cpp
@@ -23,6 +23,7 @@
 #include "application/Notification.hpp"
 #include "application/SensorBinary.hpp"
 #include "application/SensorMultilevel.hpp"
+#include "application/ThermostatMode.hpp"
 #include "application/WakeUp.hpp"
 #include "application/ZWavePlusInfo.hpp"
 
@@ -322,6 +323,16 @@ auto onGetNotification(const MessageBus::GetNotificationCommand& cmd) -> void
 auto onGetMeter(const MessageBus::GetMeterCommand& cmd) -> void
 {
     pushSendData(cmd.nodeId, cmd.callbackId, Meter::encodeGet(cmd.scale));
+}
+
+auto onSetThermostatMode(const MessageBus::SetThermostatModeCommand& cmd) -> void
+{
+    pushSendData(cmd.nodeId, cmd.callbackId, ThermostatMode::encodeSet(cmd.mode));
+}
+
+auto onGetThermostatMode(const MessageBus::GetThermostatModeCommand& cmd) -> void
+{
+    pushSendData(cmd.nodeId, cmd.callbackId, ThermostatMode::encodeGet());
 }
 
 auto onGetManufacturerSpecific(const MessageBus::GetManufacturerSpecificCommand& cmd) -> void
@@ -1009,7 +1020,7 @@ template <typename Event, typename Handler> auto subscribe(Handler&& handler) ->
 // Count of bus subscriptions registered by `subscribeBus`. Kept in sync
 // with the body — used only as a `vector::reserve` hint so off-by-one is
 // harmless beyond an extra reallocation.
-constexpr std::size_t SUBSCRIPTION_COUNT = 33;
+constexpr std::size_t SUBSCRIPTION_COUNT = 35;
 
 auto subscribeBus() -> void
 {
@@ -1031,6 +1042,8 @@ auto subscribeBus() -> void
     subscribe<MessageBus::GetSensorBinaryCommand>(onGetSensorBinary);
     subscribe<MessageBus::GetNotificationCommand>(onGetNotification);
     subscribe<MessageBus::GetMeterCommand>(onGetMeter);
+    subscribe<MessageBus::SetThermostatModeCommand>(onSetThermostatMode);
+    subscribe<MessageBus::GetThermostatModeCommand>(onGetThermostatMode);
     subscribe<MessageBus::GetManufacturerSpecificCommand>(onGetManufacturerSpecific);
     subscribe<MessageBus::GetZWavePlusInfoCommand>(onGetZWavePlusInfo);
     subscribe<MessageBus::GetNodeVersionCommand>(onGetNodeVersion);

--- a/src/zwave-protocol/application/CMakeLists.txt
+++ b/src/zwave-protocol/application/CMakeLists.txt
@@ -23,6 +23,7 @@ set_source_files_properties(
     "${ZWAVED_GENERATED_DIR}/application/ZWavePlusInfo.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorMultilevel.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorBinary.gen.cpp"
+    "${ZWAVED_GENERATED_DIR}/application/ThermostatMode.gen.cpp"
     PROPERTIES GENERATED TRUE
 )
 
@@ -45,6 +46,7 @@ target_sources(zwaved PRIVATE
     SensorBinary.cpp
     Notification.cpp
     Meter.cpp
+    ThermostatMode.cpp
     "${ZWAVED_GENERATED_DIR}/application/BinarySwitch.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/MultilevelSwitch.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/Basic.gen.cpp"
@@ -55,6 +57,7 @@ target_sources(zwaved PRIVATE
     "${ZWAVED_GENERATED_DIR}/application/ZWavePlusInfo.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorMultilevel.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorBinary.gen.cpp"
+    "${ZWAVED_GENERATED_DIR}/application/ThermostatMode.gen.cpp"
 )
 
 # Hand-written .{hpp,cpp} pairs `#include "<Name>.gen.hpp"`; expose

--- a/src/zwave-protocol/application/ThermostatMode.cpp
+++ b/src/zwave-protocol/application/ThermostatMode.cpp
@@ -1,0 +1,31 @@
+#include "ThermostatMode.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+// encodeSet / encodeGet bodies live in ThermostatMode.gen.cpp.
+
+namespace
+{
+// Report: CC + cmd + mode = 3 bytes.
+constexpr std::size_t REPORT_MIN_BYTES = 3;
+constexpr std::size_t OFFSET_MODE      = 2;
+
+// Low 5 bits of the mode byte are the mode; the high 3 bits are a v3
+// manufacturer-data-field count we don't surface.
+constexpr std::uint8_t MODE_MASK = 0x1F;
+}  // namespace
+
+auto ThermostatMode::decodeReport(std::span<const std::uint8_t> payload) -> std::optional<Report>
+{
+    if (payload.size() < REPORT_MIN_BYTES || payload[0] != COMMAND_CLASS || payload[1] != THERMOSTAT_MODE_REPORT)
+    {
+        return std::nullopt;
+    }
+
+    Report out;
+    out.mode = static_cast<std::uint8_t>(payload[OFFSET_MODE] & MODE_MASK);
+    return out;
+}

--- a/src/zwave-protocol/application/ThermostatMode.hpp
+++ b/src/zwave-protocol/application/ThermostatMode.hpp
@@ -1,0 +1,36 @@
+#ifndef ZWAVED_THERMOSTAT_MODE_HPP
+#define ZWAVED_THERMOSTAT_MODE_HPP
+
+// IWYU pragma: begin_exports
+#include "ThermostatMode.gen.hpp"
+// IWYU pragma: end_exports
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+/// Z-Wave Thermostat Mode Command Class (0x40). Sets/reads the HVAC
+/// operating mode (off / heat / cool / auto / fan only / dry / …).
+///
+/// SET and REPORT both carry a single mode byte whose low 5 bits are the
+/// mode; the high 3 bits are a v3 manufacturer-data-field count, which
+/// this decoder masks off. `encodeSet(mode)` / `encodeGet()` come from
+/// ThermostatMode.gen.hpp.
+///
+/// First of the split thermostat quartet (epic #23). SET/GET/REPORT only;
+/// SUPPORTED_GET/REPORT are not implemented.
+namespace ThermostatMode
+{
+struct Report
+{
+    std::uint8_t mode = 0;  // 0 off, 1 heat, 2 cool, 3 auto, …
+};
+
+/// Decode a Thermostat Mode Report payload (the bytes inside an
+/// APPLICATION_COMMAND_HANDLER frame, starting with COMMAND_CLASS).
+/// Returns std::nullopt if the bytes are not a well-formed Report
+/// (wrong CC/cmd or too short).
+[[nodiscard]] auto decodeReport(std::span<const std::uint8_t> payload) -> std::optional<Report>;
+}  // namespace ThermostatMode
+
+#endif  // ZWAVED_THERMOSTAT_MODE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set_source_files_properties(
     "${GENERATED_APPLICATION_DIR}/ZWavePlusInfo.gen.cpp"
     "${GENERATED_APPLICATION_DIR}/SensorMultilevel.gen.cpp"
     "${GENERATED_APPLICATION_DIR}/SensorBinary.gen.cpp"
+    "${GENERATED_APPLICATION_DIR}/ThermostatMode.gen.cpp"
     PROPERTIES GENERATED TRUE
 )
 
@@ -138,6 +139,20 @@ target_include_directories(SensorBinary_test PRIVATE
 target_link_libraries(SensorBinary_test PRIVATE GTest::gtest GTest::gtest_main)
 zwaved_test_target(SensorBinary_test)
 gtest_discover_tests(SensorBinary_test)
+
+# ---- ThermostatMode -------------------------------------------------
+add_executable(ThermostatMode_test
+    ThermostatMode_test.cpp
+    "${SRC_DIR}/application/ThermostatMode.cpp"
+    "${GENERATED_APPLICATION_DIR}/ThermostatMode.gen.cpp"
+)
+target_include_directories(ThermostatMode_test PRIVATE
+    "${SRC_DIR}/application"
+    "${GENERATED_APPLICATION_DIR}"
+)
+target_link_libraries(ThermostatMode_test PRIVATE GTest::gtest GTest::gtest_main)
+zwaved_test_target(ThermostatMode_test)
+gtest_discover_tests(ThermostatMode_test)
 
 # ---- ManufacturerSpecific -------------------------------------------
 add_executable(ManufacturerSpecific_test

--- a/tests/ThermostatMode_test.cpp
+++ b/tests/ThermostatMode_test.cpp
@@ -1,0 +1,62 @@
+#include "ThermostatMode.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+auto report(std::uint8_t modeByte) -> std::vector<std::uint8_t>
+{
+    return {ThermostatMode::COMMAND_CLASS, ThermostatMode::THERMOSTAT_MODE_REPORT, modeByte};
+}
+}  // namespace
+
+TEST(ThermostatMode, EncodeSet)
+{
+    const std::vector<std::uint8_t> expected{
+        ThermostatMode::COMMAND_CLASS, ThermostatMode::THERMOSTAT_MODE_SET, ThermostatMode::MODE_HEAT};
+    EXPECT_EQ(ThermostatMode::encodeSet(ThermostatMode::MODE_HEAT), expected);
+}
+
+TEST(ThermostatMode, EncodeGet)
+{
+    const std::vector<std::uint8_t> expected{ThermostatMode::COMMAND_CLASS, ThermostatMode::THERMOSTAT_MODE_GET};
+    EXPECT_EQ(ThermostatMode::encodeGet(), expected);
+}
+
+TEST(ThermostatMode, DecodeBasicModes)
+{
+    const auto off = ThermostatMode::decodeReport(report(ThermostatMode::MODE_OFF));
+    ASSERT_TRUE(off.has_value());
+    EXPECT_EQ(off->mode, ThermostatMode::MODE_OFF);
+
+    const auto cool = ThermostatMode::decodeReport(report(ThermostatMode::MODE_COOL));
+    ASSERT_TRUE(cool.has_value());
+    EXPECT_EQ(cool->mode, ThermostatMode::MODE_COOL);
+}
+
+TEST(ThermostatMode, DecodeMasksManufacturerDataLength)
+{
+    // High 3 bits carry a v3 manufacturer-data-field count; low 5 bits are
+    // the mode. 0x68 = (data length 3 << 5) | 0x08 (dry) → decodes as 8.
+    const auto decoded = ThermostatMode::decodeReport(report(0x68));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->mode, 0x08);
+}
+
+TEST(ThermostatMode, RejectsMalformed)
+{
+    // Too short (no mode byte).
+    const std::vector<std::uint8_t> tooShort{ThermostatMode::COMMAND_CLASS, ThermostatMode::THERMOSTAT_MODE_REPORT};
+    EXPECT_FALSE(ThermostatMode::decodeReport(tooShort).has_value());
+
+    // Wrong command class.
+    const std::vector<std::uint8_t> wrongCc{0x25, ThermostatMode::THERMOSTAT_MODE_REPORT, 0x01};
+    EXPECT_FALSE(ThermostatMode::decodeReport(wrongCc).has_value());
+
+    // Wrong command byte (Get, not Report).
+    const std::vector<std::uint8_t> wrongCmd{ThermostatMode::COMMAND_CLASS, ThermostatMode::THERMOSTAT_MODE_GET, 0x01};
+    EXPECT_FALSE(ThermostatMode::decodeReport(wrongCmd).has_value());
+}

--- a/utils/zwave-terminal/main.cpp
+++ b/utils/zwave-terminal/main.cpp
@@ -575,8 +575,11 @@ auto draw(std::uint8_t lastSession) -> void
         row++,
         0,
         "  [b] Battery  [v] Version  [m] Mfr-specific  [z] Z-Wave+  [7] Configuration  [t] Sensor  [h] Bin-sensor  "
-        "[k] Notification  [j] Meter  (GET, prompt node)");
-    mvprintw(row++, 0, "  [8] Basic set  [9] Config set  [w] Wake-up interval  [u] Assoc add  [r] Assoc remove");
+        "[k] Notification  [j] Meter  [y] Thermostat mode  (GET, prompt node)");
+    mvprintw(row++,
+             0,
+             "  [8] Basic set  [9] Config set  [0] Thermostat mode  [w] Wake-up interval  [u] Assoc add  "
+             "[r] Assoc remove");
     mvprintw(row++, 0, "  [a] Get association group members");
     mvprintw(row++, 0, "  [g] Get association group count");
     mvprintw(row++, 0, "  [L] Set lifeline (controller -> group 1)");
@@ -692,6 +695,38 @@ auto meterUnit(std::uint8_t meterType, std::uint8_t scale) -> const char*
         return scale == 0 ? "m3" : "";
     default:
         return "";
+    }
+}
+
+// Thermostat Mode (CC 0x40) name; nullptr when unknown.
+auto thermostatModeName(std::uint8_t mode) -> const char*
+{
+    switch (mode)
+    {
+    case 0:
+        return "off";
+    case 1:
+        return "heat";
+    case 2:
+        return "cool";
+    case 3:
+        return "auto";
+    case 4:
+        return "aux heat";
+    case 6:
+        return "fan only";
+    case 8:
+        return "dry";
+    case 10:
+        return "auto changeover";
+    case 11:
+        return "energy-save heat";
+    case 12:
+        return "energy-save cool";
+    case 13:
+        return "away";
+    default:
+        return nullptr;
     }
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
@@ -942,6 +977,26 @@ auto registerSignalHandlers(sdbus::IProxy& proxy) -> void
                 logLine(stream.str());
             });
     // NOLINTEND(bugprone-easily-swappable-parameters)
+
+    proxy.uponSignal("ThermostatModeReport")
+        .onInterface(IFACE_NAME)
+        .call(
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus signal
+            [](std::uint8_t sourceNodeId, std::uint8_t mode) -> void
+            {
+                std::ostringstream stream;
+                stream << "ThermostatModeReport node=" << static_cast<unsigned>(sourceNodeId) << " mode=";
+                if (const char* name = thermostatModeName(mode); name != nullptr)
+                {
+                    stream << name;
+                }
+                else
+                {
+                    stream << "0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(mode)
+                           << std::dec;
+                }
+                logLine(stream.str());
+            });
 
     proxy.uponSignal("ConfigurationReport")
         .onInterface(IFACE_NAME)
@@ -1441,6 +1496,29 @@ auto handleSetBasic(sdbus::IProxy& proxy, std::uint8_t& sessionCounter) -> void
     catch (const sdbus::Error& err)
     {
         logLine(std::string{"SetBasic failed: "} + err.what());
+    }
+}
+
+auto handleSetThermostatMode(sdbus::IProxy& proxy, std::uint8_t& sessionCounter) -> void
+{
+    auto nodeId = promptNodeId("Node ID (1-232):");
+    auto mode   = promptByte("Thermostat mode (0=off, 1=heat, 2=cool, 3=auto):", BYTE_MIN, BYTE_MAX);
+    if (!nodeId.has_value() || !mode.has_value())
+    {
+        logLine("SetThermostatMode: cancelled or invalid");
+        return;
+    }
+    ++sessionCounter;
+    try
+    {
+        proxy.callMethod("SetThermostatMode").onInterface(IFACE_NAME).withArguments(*nodeId, *mode, sessionCounter);
+        logLine("SetThermostatMode node=" + std::to_string(static_cast<unsigned>(*nodeId)) +
+                " mode=" + std::to_string(static_cast<unsigned>(*mode)) +
+                " callback=" + std::to_string(static_cast<unsigned>(sessionCounter)));
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"SetThermostatMode failed: "} + err.what());
     }
 }
 
@@ -2614,9 +2692,17 @@ auto main() -> int
             {
                 handleGetNotification(*proxy, sessionCounter);
             }
+            else if (key == 'y' || key == 'Y')
+            {
+                handleSimpleGet(*proxy, sessionCounter, "GetThermostatMode");
+            }
             else if (key == '8')
             {
                 handleSetBasic(*proxy, sessionCounter);
+            }
+            else if (key == '0')
+            {
+                handleSetThermostatMode(*proxy, sessionCounter);
             }
             else if (key == '9')
             {


### PR DESCRIPTION
Closes #103 — first of the split thermostat quartet (epic #23).

Manifest-driven vertical slice mirroring Basic (0x20): the Set carries a single byte and the Get is empty, so both encoders are generated; only `decodeReport` is hand-written.

## What's in it
- **Codec** (`ThermostatMode.{hpp,cpp}`): generated `encodeSet(mode)` / `encodeGet()`; hand-written `decodeReport` that masks the mode byte's low 5 bits (the high 3 are a v3 manufacturer-data-field count) and returns the raw mode.
- **Bus events**: `ThermostatModeReport` (cc-translator → external-api), `SetThermostatModeCommand` / `GetThermostatModeCommand` (external-api → zwave-protocol).
- **D-Bus**: `SetThermostatMode(y y y)` / `GetThermostatMode(y y)` methods + typed `ThermostatModeReport(y y)` signal via the `decode:` cc_translation.
- **ProtocolThread**: `onSetThermostatMode` / `onGetThermostatMode` handlers + subscriptions (SUBSCRIPTION_COUNT 33 → 35).
- **Terminal**: `[0]` sets the mode, `[y]` gets it; reports render with mode names (`ThermostatModeReport node=5 mode=heat`).
- **Docs/tests**: 5 codec unit tests; MANUAL §11h; TODO marked done.

`mode`: 0 off, 1 heat, 2 cool, 3 auto, 6 fan only, 8 dry, … (raw byte; naming left to clients). `SUPPORTED_GET`/`REPORT` deferred.

## Heads-up
The terminal is now **out of single-key bindings** — `[y]` and `[0]` were the last two free. The remaining quartet CCs (#104 Setpoint, #105 Operating State, #106 Fan Mode) will need a submenu or rebinding scheme; tracked under the terminal epic #73.

## Verification
- Builds clean under **both** gnu (GCC 15) and llvm (Clang 20) presets.
- `ctest` 231/231 pass (5 new ThermostatMode tests).
- clang-format + clang-tidy clean (pre-commit hook passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)