### PR TITLE
feat: Thermostat Operating State (CC 0x42) get + typed report signal

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -509,6 +509,19 @@ events:
       - { name: precision,    type: u8,  default: 0 }
       - { name: value,        type: i32, default: 0, doc: "raw; reading = value / 10^precision" }
 
+  - name: ThermostatOperatingStateReport
+    category: transient
+    direction: { publishers: [cc-translator], subscribers: [external-api] }
+    doc: |
+      Typed Thermostat Operating State (CC 0x42) Report — what the HVAC is
+      currently doing. Republished by the cc-translator from inbound
+      ApplicationCommand frames whose ccData parses as an Operating State
+      Report. `state`: 0 idle, 1 heating, 2 cooling, 3 fan only, 4 pending
+      heat, 5 pending cool, 6 vent/economizer. Read-only CC (no Set).
+    fields:
+      - { name: sourceNodeId, type: u8, default: 0 }
+      - { name: state,        type: u8, default: 0 }
+
   - name: WakeUpIntervalReport
     category: transient
     direction: { publishers: [cc-translator], subscribers: [external-api] }
@@ -918,6 +931,14 @@ events:
       - { name: setpointType, type: u8, default: 0 }
       - { name: callbackId,   type: u8, default: 0 }
 
+  - name: GetThermostatOperatingStateCommand
+    category: command
+    direction: { publishers: [external-api], subscribers: [zwave-protocol] }
+    doc: Query a node's current thermostat operating state (read-only CC).
+    fields:
+      - { name: nodeId,     type: u8, default: 0 }
+      - { name: callbackId, type: u8, default: 0 }
+
   - name: GetBatteryCommand
     category: command
     direction: { publishers: [external-api], subscribers: [zwave-protocol] }
@@ -1320,6 +1341,13 @@ dbus:
         - { name: callbackId,   dbus: y, cpp: u8 }
       action:
         publish: GetThermostatSetpointCommand
+
+    - name: GetThermostatOperatingState
+      params:
+        - { name: nodeId,     dbus: y, cpp: u8 }
+        - { name: callbackId, dbus: y, cpp: u8 }
+      action:
+        publish: GetThermostatOperatingStateCommand
 
     - name: GetManufacturerSpecific
       params:
@@ -1831,6 +1859,13 @@ dbus:
       triggered_by:
         event: ThermostatSetpointReport
 
+    - name: ThermostatOperatingStateReport
+      params:
+        - { name: sourceNodeId, dbus: y }
+        - { name: state,        dbus: y, doc: "0 idle, 1 heating, 2 cooling, 3 fan only, …" }
+      triggered_by:
+        event: ThermostatOperatingStateReport
+
     - name: ManufacturerSpecificReport
       params:
         - { name: sourceNodeId,   dbus: y }
@@ -2258,6 +2293,33 @@ modules:
           - { name: precision,    type: u8,  doc: "reading = value / 10^precision" }
           - { name: value,        type: i32, doc: "raw signed target temperature" }
 
+  - name: ThermostatOperatingState
+    wire:
+      class_byte: 0x42
+      prefix: THERMOSTAT_OPERATING_STATE
+    description: |
+      Read-only report of what the HVAC is currently doing. GET takes no
+      payload; REPORT carries a state byte (low 4 bits). state: 0 idle,
+      1 heating, 2 cooling, 3 fan only, 4 pending heat, 5 pending cool,
+      6 vent/economizer. The decoder returns the raw value and leaves
+      naming to clients. Third of the split thermostat quartet (epic #23);
+      no Set (read-only). SUPPORTED_GET/REPORT not implemented.
+    constants:
+      - { name: STATE_IDLE,    value: 0x00 }
+      - { name: STATE_HEATING, value: 0x01 }
+      - { name: STATE_COOLING, value: 0x02 }
+    commands:
+      - name: Get
+        wire:
+          byte: 0x02
+          payload: []
+        encode_args: []
+      - name: Report
+        wire:
+          byte: 0x03
+        decoded_struct:
+          - { name: state, type: u8, doc: "0 idle, 1 heating, 2 cooling, 3 fan only, …" }
+
   - name: Configuration
     wire:
       class_byte: 0x70
@@ -2614,6 +2676,16 @@ translations:
       scale:        decoded.scale
       precision:    decoded.precision
       value:        decoded.value
+
+  - publishes: ThermostatOperatingStateReport
+    triggered_by: ApplicationCommand
+    decode:
+      codec: ThermostatOperatingState.decodeReport
+      input: ccData
+      on_none: skip
+    map:
+      sourceNodeId: event.sourceNodeId
+      state:        decoded.state
 
   - publishes: ManufacturerSpecificReport
     triggered_by: ApplicationCommand

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -635,6 +635,30 @@ terminal, the `[c]` Control submenu → `[p]` sets a setpoint (prompts node,
 type, precision, scale, value) and the `[g]` Get submenu → `[p]` reads one;
 reports render as `ThermostatSetpointReport node=5 type=1 21.5 C`.
 
+## 11j. Thermostat operating state (CC 0x42)
+
+The Thermostat Operating State Command Class is a **read-only** report of
+what the HVAC is currently doing. `GetThermostatOperatingState(nodeId,
+callbackId)` polls it; the reply and any unsolicited Reports arrive as the
+typed `ThermostatOperatingStateReport(y y)` signal:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `sourceNodeId` | `y` | the reporting node |
+| `state` | `y` | 0 idle, 1 heating, 2 cooling, 3 fan only, 4 pending heat, 5 pending cool, 6 vent/economizer |
+
+```bash
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 GetThermostatOperatingState yy 5 7
+# → ThermostatOperatingStateReport y y  5 1   = node 5 heating
+```
+
+There is no Set (the state reflects the device, not a command). The decoder
+masks the low 4 bits and returns the raw state; naming is left to clients.
+`SUPPORTED_GET`/`REPORT` are not implemented. In the terminal, the `[g]` Get
+submenu → `[o]` reads it; reports render as
+`ThermostatOperatingStateReport node=5 state=heating`.
+
 ## 12. Unsolicited node events
 
 When a node sends an unsolicited Command Class frame — most commonly a

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ Implementation order (each shippable independently):
 - [ ] [epic: Thermostat HVAC quartet](https://github.com/Assar63/zwaved/issues/23) — split into per-CC subtasks (each an independent slice):
   - [x] **Thermostat Mode (CC `0x40`)** — [#103](https://github.com/Assar63/zwaved/issues/103): `SetThermostatMode(nodeId, mode, callbackId)` + `GetThermostatMode(nodeId, callbackId)` over D-Bus; generated `encodeSet`/`encodeGet`, hand-written `decodeReport` (masks the mode byte's low 5 bits — high 3 are a v3 manufacturer-data count). Republished by the cc-translator as the typed `ThermostatModeReport(y y)` signal. Terminal `[0]` sets / `[y]` gets, rendered with mode names. 5 codec unit tests. **Note:** terminal is now out of single-key bindings (only `[y]`/`[0]` were left) — the remaining quartet CCs need a submenu/rebinding scheme (follow-up under terminal epic #73). SUPPORTED_GET/REPORT deferred.
   - [x] **Thermostat Setpoint (CC `0x43`)** — [#104](https://github.com/Assar63/zwaved/issues/104): `SetThermostatSetpoint(nodeId, setpointType, precision, scale, value, callbackId)` + `GetThermostatSetpoint(nodeId, setpointType, callbackId)` over D-Bus; typed `ThermostatSetpointReport(y y y y i)` signal. **Factored the SDS13781 precision/scale/size value codec into a shared `EncodedValue.{hpp,cpp}` helper** (decode + size-picking encode) and refactored SensorMultilevel (#17) onto it — no more duplicated sign-extension logic. 9 `EncodedValue` + 8 setpoint unit tests. Terminal renders inbound reports; Set/Get key bindings deferred (terminal out of single keys — #73). SUPPORTED_GET/REPORT + CAPABILITIES_GET deferred.
-  - [ ] [Thermostat Operating State (CC 0x42)](https://github.com/Assar63/zwaved/issues/105) — read-only
+  - [x] **Thermostat Operating State (CC `0x42`)** — [#105](https://github.com/Assar63/zwaved/issues/105): read-only; `GetThermostatOperatingState(nodeId, callbackId)` over D-Bus + typed `ThermostatOperatingStateReport(y y)` signal (`state` masked to low 4 bits: 0 idle, 1 heating, 2 cooling, 3 fan only, …). Generated `encodeGet`, hand-written `decodeReport`. Terminal `[g]→[o]` gets it, rendered with state names. 4 codec unit tests. SUPPORTED_GET/REPORT deferred.
   - [ ] [Thermostat Fan Mode (CC 0x44)](https://github.com/Assar63/zwaved/issues/106)
 - [ ] [Door Lock (CC 0x62) + User Code (CC 0x63)](https://github.com/Assar63/zwaved/issues/24)
 - [ ] [Transport Service (CC 0x55)](https://github.com/Assar63/zwaved/issues/25)
@@ -148,6 +148,8 @@ Implementation order (each shippable independently):
 ## zwave-terminal client
 
 > [epic: bring zwave-terminal up to parity with the daemon](https://github.com/Assar63/zwaved/issues/73) — the terminal lags the daemon's grown surface (~11 CCs, error feed, pending queue, orchestrators). Children: #74–#77 below.
+
+- [ ] [Split main.cpp into modules (move-only refactor)](https://github.com/Assar63/zwaved/issues/111) — `main.cpp` is ~2.9k lines; split into `client` / `prompts` / `render` / `signal_handlers` / `handlers` / `policy_blob` / `main` TUs, no behaviour change. Keep the free-functions style (it's a `utils/` tool, not the daemon). Isolate the deliberately-duplicated policy BLOB codec. Do **before** the bulkier terminal items (#76 banner, #48 scenes, #44–#46 windows); the quartet CCs don't force it.
 
 ### Display
 

--- a/src/zwave-protocol/ProtocolThread.cpp
+++ b/src/zwave-protocol/ProtocolThread.cpp
@@ -24,6 +24,7 @@
 #include "application/SensorBinary.hpp"
 #include "application/SensorMultilevel.hpp"
 #include "application/ThermostatMode.hpp"
+#include "application/ThermostatOperatingState.hpp"
 #include "application/ThermostatSetpoint.hpp"
 #include "application/WakeUp.hpp"
 #include "application/ZWavePlusInfo.hpp"
@@ -346,6 +347,11 @@ auto onSetThermostatSetpoint(const MessageBus::SetThermostatSetpointCommand& cmd
 auto onGetThermostatSetpoint(const MessageBus::GetThermostatSetpointCommand& cmd) -> void
 {
     pushSendData(cmd.nodeId, cmd.callbackId, ThermostatSetpoint::encodeGet(cmd.setpointType));
+}
+
+auto onGetThermostatOperatingState(const MessageBus::GetThermostatOperatingStateCommand& cmd) -> void
+{
+    pushSendData(cmd.nodeId, cmd.callbackId, ThermostatOperatingState::encodeGet());
 }
 
 auto onGetManufacturerSpecific(const MessageBus::GetManufacturerSpecificCommand& cmd) -> void
@@ -1033,7 +1039,7 @@ template <typename Event, typename Handler> auto subscribe(Handler&& handler) ->
 // Count of bus subscriptions registered by `subscribeBus`. Kept in sync
 // with the body — used only as a `vector::reserve` hint so off-by-one is
 // harmless beyond an extra reallocation.
-constexpr std::size_t SUBSCRIPTION_COUNT = 37;
+constexpr std::size_t SUBSCRIPTION_COUNT = 38;
 
 auto subscribeBus() -> void
 {
@@ -1059,6 +1065,7 @@ auto subscribeBus() -> void
     subscribe<MessageBus::GetThermostatModeCommand>(onGetThermostatMode);
     subscribe<MessageBus::SetThermostatSetpointCommand>(onSetThermostatSetpoint);
     subscribe<MessageBus::GetThermostatSetpointCommand>(onGetThermostatSetpoint);
+    subscribe<MessageBus::GetThermostatOperatingStateCommand>(onGetThermostatOperatingState);
     subscribe<MessageBus::GetManufacturerSpecificCommand>(onGetManufacturerSpecific);
     subscribe<MessageBus::GetZWavePlusInfoCommand>(onGetZWavePlusInfo);
     subscribe<MessageBus::GetNodeVersionCommand>(onGetNodeVersion);

--- a/src/zwave-protocol/application/CMakeLists.txt
+++ b/src/zwave-protocol/application/CMakeLists.txt
@@ -24,6 +24,7 @@ set_source_files_properties(
     "${ZWAVED_GENERATED_DIR}/application/SensorMultilevel.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorBinary.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/ThermostatMode.gen.cpp"
+    "${ZWAVED_GENERATED_DIR}/application/ThermostatOperatingState.gen.cpp"
     PROPERTIES GENERATED TRUE
 )
 
@@ -49,6 +50,7 @@ target_sources(zwaved PRIVATE
     Meter.cpp
     ThermostatMode.cpp
     ThermostatSetpoint.cpp
+    ThermostatOperatingState.cpp
     "${ZWAVED_GENERATED_DIR}/application/BinarySwitch.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/MultilevelSwitch.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/Basic.gen.cpp"
@@ -60,6 +62,7 @@ target_sources(zwaved PRIVATE
     "${ZWAVED_GENERATED_DIR}/application/SensorMultilevel.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/SensorBinary.gen.cpp"
     "${ZWAVED_GENERATED_DIR}/application/ThermostatMode.gen.cpp"
+    "${ZWAVED_GENERATED_DIR}/application/ThermostatOperatingState.gen.cpp"
 )
 
 # Hand-written .{hpp,cpp} pairs `#include "<Name>.gen.hpp"`; expose

--- a/src/zwave-protocol/application/ThermostatOperatingState.cpp
+++ b/src/zwave-protocol/application/ThermostatOperatingState.cpp
@@ -1,0 +1,31 @@
+#include "ThermostatOperatingState.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+// encodeGet body lives in ThermostatOperatingState.gen.cpp (empty payload).
+
+namespace
+{
+// Report: CC + cmd + state = 3 bytes.
+constexpr std::size_t REPORT_MIN_BYTES = 3;
+constexpr std::size_t OFFSET_STATE     = 2;
+
+// Low 4 bits of the byte are the operating state; high bits reserved.
+constexpr std::uint8_t STATE_MASK = 0x0F;
+}  // namespace
+
+auto ThermostatOperatingState::decodeReport(std::span<const std::uint8_t> payload) -> std::optional<Report>
+{
+    if (payload.size() < REPORT_MIN_BYTES || payload[0] != COMMAND_CLASS ||
+        payload[1] != THERMOSTAT_OPERATING_STATE_REPORT)
+    {
+        return std::nullopt;
+    }
+
+    Report out;
+    out.state = static_cast<std::uint8_t>(payload[OFFSET_STATE] & STATE_MASK);
+    return out;
+}

--- a/src/zwave-protocol/application/ThermostatOperatingState.hpp
+++ b/src/zwave-protocol/application/ThermostatOperatingState.hpp
@@ -1,0 +1,34 @@
+#ifndef ZWAVED_THERMOSTAT_OPERATING_STATE_HPP
+#define ZWAVED_THERMOSTAT_OPERATING_STATE_HPP
+
+// IWYU pragma: begin_exports
+#include "ThermostatOperatingState.gen.hpp"
+// IWYU pragma: end_exports
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+/// Z-Wave Thermostat Operating State Command Class (0x42). Read-only report
+/// of what the HVAC is currently doing (idle / heating / cooling / fan).
+///
+/// GET takes no payload; REPORT carries a state byte whose low 4 bits are
+/// the state. `encodeGet()` comes from ThermostatOperatingState.gen.hpp.
+///
+/// Third of the split thermostat quartet (epic #23). GET/REPORT only — no
+/// Set (read-only CC); SUPPORTED_GET/REPORT are not implemented.
+namespace ThermostatOperatingState
+{
+struct Report
+{
+    std::uint8_t state = 0;  // 0 idle, 1 heating, 2 cooling, 3 fan only, …
+};
+
+/// Decode a Thermostat Operating State Report payload (the bytes inside an
+/// APPLICATION_COMMAND_HANDLER frame, starting with COMMAND_CLASS).
+/// Returns std::nullopt if the bytes are not a well-formed Report
+/// (wrong CC/cmd or too short).
+[[nodiscard]] auto decodeReport(std::span<const std::uint8_t> payload) -> std::optional<Report>;
+}  // namespace ThermostatOperatingState
+
+#endif  // ZWAVED_THERMOSTAT_OPERATING_STATE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set_source_files_properties(
     "${GENERATED_APPLICATION_DIR}/SensorMultilevel.gen.cpp"
     "${GENERATED_APPLICATION_DIR}/SensorBinary.gen.cpp"
     "${GENERATED_APPLICATION_DIR}/ThermostatMode.gen.cpp"
+    "${GENERATED_APPLICATION_DIR}/ThermostatOperatingState.gen.cpp"
     PROPERTIES GENERATED TRUE
 )
 
@@ -183,6 +184,20 @@ target_include_directories(ThermostatSetpoint_test PRIVATE
 target_link_libraries(ThermostatSetpoint_test PRIVATE GTest::gtest GTest::gtest_main)
 zwaved_test_target(ThermostatSetpoint_test)
 gtest_discover_tests(ThermostatSetpoint_test)
+
+# ---- ThermostatOperatingState ---------------------------------------
+add_executable(ThermostatOperatingState_test
+    ThermostatOperatingState_test.cpp
+    "${SRC_DIR}/application/ThermostatOperatingState.cpp"
+    "${GENERATED_APPLICATION_DIR}/ThermostatOperatingState.gen.cpp"
+)
+target_include_directories(ThermostatOperatingState_test PRIVATE
+    "${SRC_DIR}/application"
+    "${GENERATED_APPLICATION_DIR}"
+)
+target_link_libraries(ThermostatOperatingState_test PRIVATE GTest::gtest GTest::gtest_main)
+zwaved_test_target(ThermostatOperatingState_test)
+gtest_discover_tests(ThermostatOperatingState_test)
 
 # ---- ManufacturerSpecific -------------------------------------------
 add_executable(ManufacturerSpecific_test

--- a/tests/ThermostatOperatingState_test.cpp
+++ b/tests/ThermostatOperatingState_test.cpp
@@ -1,0 +1,63 @@
+#include "ThermostatOperatingState.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+auto report(std::uint8_t stateByte) -> std::vector<std::uint8_t>
+{
+    return {ThermostatOperatingState::COMMAND_CLASS,
+            ThermostatOperatingState::THERMOSTAT_OPERATING_STATE_REPORT,
+            stateByte};
+}
+}  // namespace
+
+TEST(ThermostatOperatingState, EncodeGet)
+{
+    const std::vector<std::uint8_t> expected{ThermostatOperatingState::COMMAND_CLASS,
+                                             ThermostatOperatingState::THERMOSTAT_OPERATING_STATE_GET};
+    EXPECT_EQ(ThermostatOperatingState::encodeGet(), expected);
+}
+
+TEST(ThermostatOperatingState, DecodeStates)
+{
+    const auto idle = ThermostatOperatingState::decodeReport(report(ThermostatOperatingState::STATE_IDLE));
+    ASSERT_TRUE(idle.has_value());
+    EXPECT_EQ(idle->state, ThermostatOperatingState::STATE_IDLE);
+
+    const auto heating = ThermostatOperatingState::decodeReport(report(ThermostatOperatingState::STATE_HEATING));
+    ASSERT_TRUE(heating.has_value());
+    EXPECT_EQ(heating->state, ThermostatOperatingState::STATE_HEATING);
+
+    const auto cooling = ThermostatOperatingState::decodeReport(report(ThermostatOperatingState::STATE_COOLING));
+    ASSERT_TRUE(cooling.has_value());
+    EXPECT_EQ(cooling->state, ThermostatOperatingState::STATE_COOLING);
+}
+
+TEST(ThermostatOperatingState, DecodeMasksReservedBits)
+{
+    // High 4 bits are reserved; low 4 bits carry the state. 0x21 → 1 (heating).
+    const auto decoded = ThermostatOperatingState::decodeReport(report(0x21));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->state, 0x01);
+}
+
+TEST(ThermostatOperatingState, RejectsMalformed)
+{
+    // Too short (no state byte).
+    const std::vector<std::uint8_t> tooShort{ThermostatOperatingState::COMMAND_CLASS,
+                                             ThermostatOperatingState::THERMOSTAT_OPERATING_STATE_REPORT};
+    EXPECT_FALSE(ThermostatOperatingState::decodeReport(tooShort).has_value());
+
+    // Wrong command class.
+    const std::vector<std::uint8_t> wrongCc{0x40, ThermostatOperatingState::THERMOSTAT_OPERATING_STATE_REPORT, 0x01};
+    EXPECT_FALSE(ThermostatOperatingState::decodeReport(wrongCc).has_value());
+
+    // Wrong command byte (Get, not Report).
+    const std::vector<std::uint8_t> wrongCmd{
+        ThermostatOperatingState::COMMAND_CLASS, ThermostatOperatingState::THERMOSTAT_OPERATING_STATE_GET, 0x01};
+    EXPECT_FALSE(ThermostatOperatingState::decodeReport(wrongCmd).has_value());
+}

--- a/utils/zwave-terminal/main.cpp
+++ b/utils/zwave-terminal/main.cpp
@@ -749,6 +749,30 @@ auto thermostatModeName(std::uint8_t mode) -> const char*
         return nullptr;
     }
 }
+
+// Thermostat Operating State (CC 0x42) name; nullptr when unknown.
+auto thermostatOperatingStateName(std::uint8_t state) -> const char*
+{
+    switch (state)
+    {
+    case 0:
+        return "idle";
+    case 1:
+        return "heating";
+    case 2:
+        return "cooling";
+    case 3:
+        return "fan only";
+    case 4:
+        return "pending heat";
+    case 5:
+        return "pending cool";
+    case 6:
+        return "vent/economizer";
+    default:
+        return nullptr;
+    }
+}
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
 // NOLINTBEGIN(readability-function-cognitive-complexity): flat list of signal subscriptions
@@ -1018,8 +1042,26 @@ auto registerSignalHandlers(sdbus::IProxy& proxy) -> void
                 logLine(stream.str());
             });
 
-    // Display only — Set/Get key bindings are deferred until the terminal's
-    // single-key menu is reworked (out of free keys; terminal epic #73).
+    proxy.uponSignal("ThermostatOperatingStateReport")
+        .onInterface(IFACE_NAME)
+        .call(
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus signal
+            [](std::uint8_t sourceNodeId, std::uint8_t state) -> void
+            {
+                std::ostringstream stream;
+                stream << "ThermostatOperatingStateReport node=" << static_cast<unsigned>(sourceNodeId) << " state=";
+                if (const char* name = thermostatOperatingStateName(state); name != nullptr)
+                {
+                    stream << name;
+                }
+                else
+                {
+                    stream << "0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(state)
+                           << std::dec;
+                }
+                logLine(stream.str());
+            });
+
     proxy.uponSignal("ThermostatSetpointReport")
         .onInterface(IFACE_NAME)
         .call(
@@ -2768,6 +2810,9 @@ auto main() -> int
                         {'n', "Notification", [&] { handleGetNotification(*proxy, sessionCounter); }},
                         {'t', "Thermostat mode", [&] { handleSimpleGet(*proxy, sessionCounter, "GetThermostatMode"); }},
                         {'p', "Thermostat setpoint", [&] { handleGetThermostatSetpoint(*proxy, sessionCounter); }},
+                        {'o',
+                         "Thermostat operating state",
+                         [&] { handleSimpleGet(*proxy, sessionCounter, "GetThermostatOperatingState"); }},
                         {'w', "Multilevel switch", [&] { handleGetMultilevelSwitch(*proxy, sessionCounter); }},
                         {'a', "Association members", [&] { handleGetAssociation(*proxy, sessionCounter); }},
                         {'r', "Association groupings", [&] { handleGetAssociationGroupings(*proxy, sessionCounter); }},


### PR DESCRIPTION
Closes #105 — third of the split thermostat quartet (epic #23).

Read-only CC reporting what the HVAC is currently doing. The submenu rework (#110) made the terminal side a one-line addition.

## What's in it
- **Codec** (`ThermostatOperatingState.{hpp,cpp}`): generated `encodeGet()` (empty payload); hand-written `decodeReport` masking the state byte's low 4 bits.
- **Bus events**: `ThermostatOperatingStateReport` (cc-translator → external-api), `GetThermostatOperatingStateCommand` (external-api → zwave-protocol).
- **D-Bus**: `GetThermostatOperatingState(y y)` method + typed `ThermostatOperatingStateReport(y y)` signal via the `decode:` cc_translation. No Set (read-only).
- **ProtocolThread**: `onGetThermostatOperatingState` + subscription (SUBSCRIPTION_COUNT 37 → 38).
- **Terminal**: `[g]` Get submenu → `[o]`, rendered with state names (`ThermostatOperatingStateReport node=5 state=heating`).
- **Docs/tests**: 4 codec unit tests; MANUAL §11j; TODO marked done.

`state`: 0 idle, 1 heating, 2 cooling, 3 fan only, 4 pending heat, 5 pending cool, 6 vent/economizer. `SUPPORTED_GET`/`REPORT` deferred.

Also records the terminal split-refactor issue (#111) in TODO.md.

## Quartet status
3 of 4 done — only **Fan Mode (#106)** remains.

## Verification
- Builds clean under **both** gnu (GCC 15) and llvm (Clang 20).
- `ctest` 251/251 pass (4 new tests).
- clang-format + clang-tidy clean (pre-commit hook passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)