### PR TITLE
feat: surface dongle library type by name + scripts/zw-dongle-probe

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1023,12 +1023,27 @@ two host-API requests synchronously and caches the answers:
 
 Both values are emitted on D-Bus as a `DongleInfo(s y ay y)` signal
 and cached so `GetDongleInfo()` can return the latest snapshot to
-clients that connect later.
+clients that connect later. The daemon also logs the library type by
+name on connect (e.g. `lib type 1 Static Controller`), and the
+`zwave-terminal` `[i]` view renders it as `libType=1 (Static
+Controller)`.
 
 ```bash
 busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
     com.tiunda.ZWaved1 GetDongleInfo
 ```
+
+To read the library type **without** the daemon running (e.g. to check
+whether a dongle is a Bridge Controller before planning virtual-node
+work), use the standalone probe:
+
+```bash
+scripts/zw-dongle-probe                 # defaults to /dev/ttyACM0
+scripts/zw-dongle-probe --port /dev/ttyACM1
+```
+
+Library type `7` (Bridge Controller) is the only one that can host
+virtual slave nodes; a Static Controller (`1`) cannot.
 
 If a dongle has not yet been introspected (none plugged in since the
 daemon started), `GetDongleInfo` returns an empty struct (empty

--- a/scripts/zw-dongle-probe
+++ b/scripts/zw-dongle-probe
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Probe a Z-Wave serial dongle for its library type (and version).
+
+Sends a FUNC_ID_ZW_GET_VERSION (0x15) frame over the Serial API and decodes
+the trailing library-type byte. Library type 7 (Bridge Controller) is the one
+that can host virtual slave nodes; a Static Controller (1) cannot — see
+FUTURE.md.
+
+This is a standalone diagnostic: it talks to the raw TTY and does NOT need the
+zwaved daemon running. Stop the daemon first if it owns the port. Requires
+pyserial (`pip install pyserial`) and membership in the `dialout` group (or
+root) to open the device.
+
+Usage:
+    scripts/zw-dongle-probe [--port /dev/ttyACM0] [--timeout 2.5]
+"""
+import argparse
+import sys
+import time
+
+try:
+    import serial  # pyserial
+except ImportError:
+    sys.exit("error: pyserial not installed (try: pip install pyserial)")
+
+SOF = 0x01
+ACK = 0x06
+GET_VERSION = 0x15
+VERSION_STRING_LEN = 12
+
+LIBRARY_TYPES = {
+    1: "Static Controller",
+    2: "Controller",
+    3: "Enhanced Slave",
+    4: "Slave",
+    5: "Installer",
+    6: "Routing Slave",
+    7: "Bridge Controller",
+    8: "DUT",
+}
+
+
+def checksum(payload: bytes) -> int:
+    """Z-Wave Serial API checksum: 0xFF XOR every byte from LEN..last-data."""
+    chk = 0xFF
+    for byte in payload:
+        chk ^= byte
+    return chk
+
+
+def build_request(func: int) -> bytes:
+    body = bytes([0x00, func])  # type=REQUEST(0x00), funcID
+    payload = bytes([len(body) + 1]) + body  # LEN counts type+cmd+checksum
+    return bytes([SOF]) + payload + bytes([checksum(payload)])
+
+
+def find_response(buf: bytes, func: int):
+    """Return the first well-formed RESPONSE data frame for `func`, or None."""
+    i = 0
+    while i < len(buf):
+        if buf[i] == SOF and i + 1 < len(buf):
+            length = buf[i + 1]
+            end = i + 2 + length  # SOF + LEN + `length` bytes
+            if end <= len(buf) and i + 3 < len(buf) and buf[i + 3] == func:
+                return buf[i:end]
+        i += 1
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe a Z-Wave dongle's library type.")
+    parser.add_argument("--port", default="/dev/ttyACM0", help="serial device (default: /dev/ttyACM0)")
+    parser.add_argument("--timeout", type=float, default=2.5, help="read timeout seconds (default: 2.5)")
+    args = parser.parse_args()
+
+    try:
+        port = serial.Serial(args.port, 115200, timeout=0.3)
+    except serial.SerialException as exc:
+        return f"error: cannot open {args.port}: {exc}"
+
+    with port:
+        time.sleep(0.2)
+        port.reset_input_buffer()
+        request = build_request(GET_VERSION)
+        port.write(request)
+        port.flush()
+
+        buf = bytearray()
+        deadline = time.time() + args.timeout
+        while time.time() < deadline:
+            chunk = port.read(64)
+            if chunk:
+                buf += chunk
+                if find_response(buf, GET_VERSION) is not None:
+                    break
+
+        frame = find_response(buf, GET_VERSION)
+        if frame is None:
+            return f"error: no GET_VERSION response from {args.port} (raw: {bytes(buf).hex(' ') or 'nothing'})"
+
+        port.write(bytes([ACK]))
+        port.flush()
+
+        data = frame[4:-1]  # strip SOF, LEN, TYPE, CMD and trailing checksum
+        version = bytes(data[:VERSION_STRING_LEN]).split(b"\x00")[0].decode("ascii", "replace")
+        lib = data[VERSION_STRING_LEN] if len(data) > VERSION_STRING_LEN else None
+        name = LIBRARY_TYPES.get(lib, "unknown")
+        print(f"port        : {args.port}")
+        print(f"version     : {version}")
+        print(f"libraryType : {lib} ({name})")
+        if lib == 7:
+            print("note        : Bridge Controller — can host virtual slave nodes.")
+        else:
+            print("note        : NOT a Bridge Controller — cannot host virtual slave nodes (see FUTURE.md).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/zwave-protocol/HostApi.cpp
+++ b/src/zwave-protocol/HostApi.cpp
@@ -261,6 +261,31 @@ auto HostApi::decodeVersion(const ZwaveDataFrame& frame) -> std::optional<Versio
     return out;
 }
 
+auto HostApi::libraryTypeName(uint8_t libraryType) -> const char*
+{
+    switch (libraryType)
+    {
+    case LIBRARY_TYPE_STATIC_CONTROLLER:
+        return "Static Controller";
+    case LIBRARY_TYPE_CONTROLLER:
+        return "Controller";
+    case LIBRARY_TYPE_ENHANCED_SLAVE:
+        return "Enhanced Slave";
+    case LIBRARY_TYPE_SLAVE:
+        return "Slave";
+    case LIBRARY_TYPE_INSTALLER:
+        return "Installer";
+    case LIBRARY_TYPE_ROUTING_SLAVE:
+        return "Routing Slave";
+    case LIBRARY_TYPE_BRIDGE_CONTROLLER:
+        return "Bridge Controller";
+    case LIBRARY_TYPE_DUT:
+        return "DUT";
+    default:
+        return "unknown";
+    }
+}
+
 auto HostApi::decodeInitData(const ZwaveDataFrame& frame) -> std::optional<InitDataResponse>
 {
     if (!frame.isValid() || frame.getCommand() != CMD_SERIAL_API_GET_INIT_DATA ||

--- a/src/zwave-protocol/HostApi.hpp
+++ b/src/zwave-protocol/HostApi.hpp
@@ -275,6 +275,10 @@ struct NodeStatusCallback
 /// Decode a FUNC_ID_GET_VERSION (0x15) RESPONSE.
 [[nodiscard]] auto decodeVersion(const ZwaveDataFrame& frame) -> std::optional<VersionResponse>;
 
+/// Human-readable name for a LIBRARY_TYPE_* value (e.g. "Static Controller",
+/// "Bridge Controller"); "unknown" for an unrecognised type.
+[[nodiscard]] auto libraryTypeName(uint8_t libraryType) -> const char*;
+
 /// Decode a FUNC_ID_MEMORY_GET_ID (0x20) RESPONSE.
 [[nodiscard]] auto decodeMemoryId(const ZwaveDataFrame& frame) -> std::optional<MemoryIdResponse>;
 

--- a/src/zwave-protocol/ProtocolThread.cpp
+++ b/src/zwave-protocol/ProtocolThread.cpp
@@ -1194,7 +1194,8 @@ auto zwaveCommunicationThread() -> void
             MessageBus::publish(MessageBus::DaemonError{});
             const auto& info = *introspection.dongleInfo;
             Logger::info("[ProtocolThread] dongle " + info.libraryVersion + " (lib type " +
-                         std::to_string(static_cast<int>(info.libraryType)) + ", controller node " +
+                         std::to_string(static_cast<int>(info.libraryType)) + " " +
+                         HostApi::libraryTypeName(info.libraryType) + ", controller node " +
                          std::to_string(static_cast<int>(info.controllerNodeId)) + ")");
             state().controllerNodeId = info.controllerNodeId;
             // Bind the registry to this network *before* seeding from

--- a/utils/zwave-terminal/format.cpp
+++ b/utils/zwave-terminal/format.cpp
@@ -302,6 +302,34 @@ auto centralSceneKeyName(std::uint8_t keyAttribute) -> const char*
         return nullptr;
     }
 }
+
+// Controller library type (FUNC_ID_GET_VERSION) name; mirrors
+// HostApi::LIBRARY_TYPE_*. Bridge Controller (7) is the one that can host
+// virtual slave nodes.
+auto libraryTypeName(std::uint8_t libraryType) -> const char*
+{
+    switch (libraryType)
+    {
+    case 1:
+        return "Static Controller";
+    case 2:
+        return "Controller";
+    case 3:
+        return "Enhanced Slave";
+    case 4:
+        return "Slave";
+    case 5:
+        return "Installer";
+    case 6:
+        return "Routing Slave";
+    case 7:
+        return "Bridge Controller";
+    case 8:
+        return "DUT";
+    default:
+        return "unknown";
+    }
+}
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
 /// Z-Wave Command Class human-readable names. Covers the most commonly

--- a/utils/zwave-terminal/format.hpp
+++ b/utils/zwave-terminal/format.hpp
@@ -30,6 +30,7 @@ namespace zwt
 [[nodiscard]] auto thermostatFanModeName(std::uint8_t mode) -> const char*;
 [[nodiscard]] auto colorComponentName(std::uint8_t componentId) -> const char*;
 [[nodiscard]] auto centralSceneKeyName(std::uint8_t keyAttribute) -> const char*;
+[[nodiscard]] auto libraryTypeName(std::uint8_t libraryType) -> const char*;
 
 [[nodiscard]] auto commandClassName(std::uint8_t commandClass) -> const char*;
 [[nodiscard]] auto formatCcRange(std::vector<std::uint8_t>::const_iterator begin,

--- a/utils/zwave-terminal/handlers.cpp
+++ b/utils/zwave-terminal/handlers.cpp
@@ -663,7 +663,8 @@ auto handleDongleInfo(sdbus::IProxy& proxy) -> void
         return;
     }
     std::ostringstream stream;
-    stream << "DongleInfo: \"" << libraryVersion << "\" libType=" << static_cast<unsigned>(libraryType) << " homeId=";
+    stream << "DongleInfo: \"" << libraryVersion << "\" libType=" << static_cast<unsigned>(libraryType) << " ("
+           << libraryTypeName(libraryType) << ") homeId=";
     for (const auto byte : homeId)
     {
         stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(byte);


### PR DESCRIPTION
The dongle's library type (Static Controller vs Bridge Controller, …) was already decoded in `HostApi.cpp` and carried in `DongleInfo` over D-Bus — but only as a raw number. This makes it human-readable where it's actually read, and adds a standalone probe (promoted from the throwaway used during the FUTURE.md virtual-nodes decision gate).

## Changes
- **Daemon**: `HostApi::libraryTypeName()` maps `LIBRARY_TYPE_*` → name; the ProtocolThread introspection log now reads `lib type 1 Static Controller` instead of a bare number.
- **Terminal**: `format::libraryTypeName()` + the `[i]` DongleInfo view renders `libType=1 (Static Controller)`.
- **`scripts/zw-dongle-probe`**: standalone pyserial `FUNC_ID_ZW_GET_VERSION` probe that reports the library type **without the daemon running** — for checking Bridge Controller support before planning virtual-node work (FUTURE.md). Runs against the bench Z-Stick Gen5 and reports `Z-Wave 3.99`, libraryType **1 (Static Controller)**.
- **MANUAL**: documents the named rendering + the probe.

No manifest change — `libraryType` is already a `DongleInfo` field/signal/`GetDongleInfo` return.

## Verification
- Builds clean under **both** gnu (GCC 15) and llvm (Clang 20).
- `ctest` 278/278 pass.
- clang-format + clang-tidy clean; `scripts/zw-dongle-probe` runs against real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)