### PR TITLE
feat: SceneOrchestrator — run scenes from Central Scene presses

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -646,6 +646,23 @@ events:
     fields:
       - { name: nodeId, type: u8, default: 0 }
 
+  - name: SceneActivated
+    category: transient
+    direction: { publishers: [orchestrator], subscribers: [external-api] }
+    doc: |
+      SceneOrchestrator (#121) ran a scene in response to a physical press.
+      A CentralSceneNotification `(sourceNodeId, sceneNumber, keyAttribute)`
+      resolved to scene `sceneId` in the scene store (#120); the
+      orchestrator replayed its `actionCount` actions as SendData commands.
+      Observability only (and the hook the terminal renders). Not published
+      when a press resolves to no scene.
+    fields:
+      - { name: sourceNodeId, type: u8,     default: 0 }
+      - { name: sceneNumber,  type: u8,     default: 0 }
+      - { name: keyAttribute, type: u8,     default: 0 }
+      - { name: sceneId,      type: string }
+      - { name: actionCount,  type: u32,    default: 0 }
+
   - name: ConfigurationReport
     category: transient
     direction: { publishers: [cc-translator], subscribers: [external-api, orchestrator] }

--- a/src/orchestrator/CMakeLists.txt
+++ b/src/orchestrator/CMakeLists.txt
@@ -9,4 +9,5 @@
 target_sources(zwaved PRIVATE
     WakeUpOrchestrator.cpp
     InclusionOrchestrator.cpp
+    SceneOrchestrator.cpp
 )

--- a/src/orchestrator/SceneOrchestrator.cpp
+++ b/src/orchestrator/SceneOrchestrator.cpp
@@ -1,0 +1,107 @@
+// SceneOrchestrator (#121) — runs daemon-side scenes from physical button
+// presses. A Central Scene controller (wall switch / remote) associated to
+// the controller node sends a CENTRAL_SCENE NOTIFICATION; the cc-translator
+// republishes it as the typed CentralSceneNotification bus event. This
+// orchestrator resolves the press `(sourceNodeId, sceneNumber, keyAttribute)`
+// against the scene store's trigger table (#120) and, on a hit, replays the
+// bound scene's actions as SendDataCommands against the target nodes — then
+// publishes SceneActivated for observers.
+//
+// Loose-coupling rule (same as the other orchestrators): bus-only, owns no
+// thread, reacts synchronously to the bus event under the recursive bus
+// mutex; the SendDataCommand / SceneActivated events it publishes are
+// delivered depth-first before control returns to the cc-translator. The
+// `(sourceNodeId, sceneNumber, keyAttribute)` key is what lets the same scene
+// number from different senders run different scenes (FUTURE.md E2).
+
+#include "../logger/Logger.hpp"
+#include "../message-bus/MessageBus.hpp"
+#include "../scene-store/SceneStore.hpp"
+#include "../zwaved.h"  // IWYU pragma: keep — CONFIG_ORCHESTRATOR_PRIO
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace
+{
+// Scene actions are fire-and-forget; the stored payload carries no callback
+// correlation. 0 is the Serial API's "no callback requested" sentinel.
+constexpr std::uint8_t NO_CALLBACK = 0x00;
+
+// NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public member reads like a struct
+struct State
+{
+    MessageBus::SubscriptionGuard sceneSub;  // auto-unsubscribes on teardown
+
+    State() = default;
+    ~State()
+    {
+        Logger::info("[SceneOrchestrator] shutdown complete");
+    }
+
+    State(const State&)                        = delete;
+    auto operator=(const State&) -> State&     = delete;
+    State(State&&) noexcept                    = delete;
+    auto operator=(State&&) noexcept -> State& = delete;
+};
+// NOLINTEND(misc-non-private-member-variables-in-classes)
+
+auto state() -> State&
+{
+    static State instance;
+    return instance;
+}
+
+auto onCentralScene(const MessageBus::CentralSceneNotification& note) -> void
+{
+    const std::optional<std::string> sceneId =
+        SceneStore::instance().resolveTrigger(note.sourceNodeId, note.sceneNumber, note.keyAttribute);
+    if (!sceneId.has_value())
+    {
+        return;  // press not bound to any scene — nothing to do
+    }
+
+    const std::optional<std::vector<SceneStore::Action>> actions = SceneStore::instance().getScene(*sceneId);
+    std::uint32_t dispatched                                     = 0;
+    if (actions.has_value())
+    {
+        for (const auto& action : *actions)
+        {
+            MessageBus::publish(MessageBus::SendDataCommand{
+                .nodeId     = action.targetNodeId,
+                .payload    = action.ccPayload,
+                .callbackId = NO_CALLBACK,
+            });
+            ++dispatched;
+        }
+    }
+    else
+    {
+        // A trigger pointing at a deleted scene — log it; the press is
+        // still reported as activated with zero actions.
+        Logger::warn("[SceneOrchestrator] trigger for node " + std::to_string(note.sourceNodeId) +
+                     " resolved to missing scene '" + *sceneId + "'");
+    }
+
+    MessageBus::publish(MessageBus::SceneActivated{
+        .sourceNodeId = note.sourceNodeId,
+        .sceneNumber  = note.sceneNumber,
+        .keyAttribute = note.keyAttribute,
+        .sceneId      = *sceneId,
+        .actionCount  = dispatched,
+    });
+
+    Logger::info("[SceneOrchestrator] node " + std::to_string(note.sourceNodeId) + " scene " +
+                 std::to_string(note.sceneNumber) + " → '" + *sceneId + "' (" + std::to_string(dispatched) +
+                 " action(s))");
+}
+
+__attribute__((constructor(CONFIG_ORCHESTRATOR_PRIO))) auto startSceneOrchestrator() -> void
+{
+    state().sceneSub =
+        MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::CentralSceneNotification>(onCentralScene));
+    Logger::info("[SceneOrchestrator] watching for scene presses");
+}
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -545,6 +545,30 @@ target_link_libraries(WakeUpOrchestrator_test PRIVATE
 zwaved_test_target(WakeUpOrchestrator_test)
 gtest_discover_tests(WakeUpOrchestrator_test)
 
+# ---- SceneOrchestrator ----------------------------------------------
+add_executable(SceneOrchestrator_test
+    SceneOrchestrator_test.cpp
+    "${CMAKE_SOURCE_DIR}/src/orchestrator/SceneOrchestrator.cpp"
+    "${CMAKE_SOURCE_DIR}/src/scene-store/SceneStore.cpp"
+    "${CMAKE_SOURCE_DIR}/src/logger/Logger.cpp"
+    "${CMAKE_SOURCE_DIR}/src/message-bus/MessageBus.cpp"
+    "${ZWAVED_GENERATED_DIR}/MessageBus.gen.cpp"
+)
+target_include_directories(SceneOrchestrator_test PRIVATE
+    "${CMAKE_SOURCE_DIR}/src/scene-store"
+    "${CMAKE_SOURCE_DIR}/src/message-bus"
+    "${ZWAVED_GENERATED_DIR}"
+)
+add_dependencies(SceneOrchestrator_test zwaved_codegen)
+target_link_libraries(SceneOrchestrator_test PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    PkgConfig::SQLITE3
+    eventpp::eventpp
+)
+zwaved_test_target(SceneOrchestrator_test)
+gtest_discover_tests(SceneOrchestrator_test)
+
 # ---- InclusionOrchestrator ------------------------------------------
 # Bus-driven: publishes NodeIncluded, asserts on the lifeline + policy
 # command sequence. Links the orchestrator (armed by its constructor),

--- a/tests/SceneOrchestrator_test.cpp
+++ b/tests/SceneOrchestrator_test.cpp
@@ -1,0 +1,136 @@
+#include "MessageBus.hpp"
+#include "SceneStore.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Bus-driven test for SceneOrchestrator (#121). No live dongle: we seed the
+// scene store (a scene + a trigger), publish a CentralSceneNotification, and
+// assert on the SendDataCommands + SceneActivated the orchestrator emits.
+//
+// The orchestrator arms its subscription via __attribute__((constructor)) at
+// load, so linking SceneOrchestrator.cpp is enough. It uses
+// SceneStore::instance(), whose DB path resolves from a StorageConfig bus
+// event — we point that at a per-process tmp file in SetUpTestSuite before
+// the singleton first opens.
+
+namespace
+{
+using MessageBus::SubscriptionGuard;
+
+const std::vector<std::uint8_t> kHomeId{0xE2, 0xA1, 0xB0, 0x7C};
+
+auto payload(std::initializer_list<std::uint8_t> bytes) -> std::vector<std::uint8_t>
+{
+    return {bytes};
+}
+
+struct Recorder
+{
+    std::vector<std::string> log;
+    std::vector<SubscriptionGuard> guards;
+
+    Recorder()
+    {
+        guards.emplace_back(MessageBus::subscribe<MessageBus::SendDataCommand>(
+            [this](const MessageBus::SendDataCommand& cmd)
+            {
+                std::string entry = "send:" + std::to_string(cmd.nodeId) + ":";
+                for (const auto byte : cmd.payload)
+                {
+                    entry += std::to_string(byte) + ",";
+                }
+                log.push_back(entry);
+            }));
+        guards.emplace_back(MessageBus::subscribe<MessageBus::SceneActivated>(
+            [this](const MessageBus::SceneActivated& evt)
+            {
+                log.push_back("scene:" + std::to_string(evt.sourceNodeId) + ":" + evt.sceneId + ":" +
+                              std::to_string(evt.actionCount));
+            }));
+    }
+};
+
+class SceneOrchestratorTest : public ::testing::Test
+{
+  protected:
+    static std::filesystem::path dbPath_;
+
+    static void SetUpTestSuite()
+    {
+        const auto unique = std::to_string(::getpid()) + "-" + std::to_string(std::random_device{}());
+        dbPath_           = std::filesystem::temp_directory_path() / ("zwaved-sceneorch-test-" + unique + ".db");
+        MessageBus::publish(MessageBus::StorageConfig{.stateDir = dbPath_.parent_path().string()});
+        SceneStore::instance().setHomeId(kHomeId);
+    }
+
+    static void TearDownTestSuite()
+    {
+        std::error_code errorCode;
+        std::filesystem::remove(dbPath_, errorCode);
+    }
+};
+
+std::filesystem::path SceneOrchestratorTest::dbPath_;
+}  // namespace
+
+TEST_F(SceneOrchestratorTest, RunsBoundSceneActionsInOrder)
+{
+    // Scene "tv" turns node 5 on and node 6 off; bound to node 7 / scene 1 / press 1x.
+    SceneStore::instance().setScene("tv",
+                                    {SceneStore::Action{.targetNodeId = 5, .ccPayload = payload({0x25, 0x01, 0xFF})},
+                                     SceneStore::Action{.targetNodeId = 6, .ccPayload = payload({0x25, 0x01, 0x00})}});
+    SceneStore::instance().bindTrigger(7, 1, 0, "tv");
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::CentralSceneNotification{
+        .sourceNodeId = 7, .sequenceNumber = 1, .keyAttribute = 0, .sceneNumber = 1, .slowRefresh = false});
+
+    ASSERT_EQ(rec.log.size(), 3U);
+    EXPECT_EQ(rec.log[0], "send:5:37,1,255,");
+    EXPECT_EQ(rec.log[1], "send:6:37,1,0,");
+    EXPECT_EQ(rec.log[2], "scene:7:tv:2");
+}
+
+TEST_F(SceneOrchestratorTest, ContextDependentBySourceNode)
+{
+    // Same scene number (1) from two different senders runs different scenes.
+    SceneStore::instance().setScene("living",
+                                    {SceneStore::Action{.targetNodeId = 5, .ccPayload = payload({0x25, 0x01, 0xFF})}});
+    SceneStore::instance().setScene("hall",
+                                    {SceneStore::Action{.targetNodeId = 8, .ccPayload = payload({0x25, 0x01, 0x00})}});
+    SceneStore::instance().bindTrigger(20, 1, 0, "living");
+    SceneStore::instance().bindTrigger(21, 1, 0, "hall");
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::CentralSceneNotification{
+        .sourceNodeId = 21, .sequenceNumber = 9, .keyAttribute = 0, .sceneNumber = 1, .slowRefresh = false});
+
+    ASSERT_EQ(rec.log.size(), 2U);
+    EXPECT_EQ(rec.log[0], "send:8:37,1,0,");  // hall scene, not living
+    EXPECT_EQ(rec.log[1], "scene:21:hall:1");
+}
+
+TEST_F(SceneOrchestratorTest, UnboundPressIsInert)
+{
+    Recorder rec;
+    MessageBus::publish(MessageBus::CentralSceneNotification{
+        .sourceNodeId = 99, .sequenceNumber = 1, .keyAttribute = 0, .sceneNumber = 4, .slowRefresh = false});
+    EXPECT_TRUE(rec.log.empty());  // no trigger → no SendData, no SceneActivated
+}
+
+TEST_F(SceneOrchestratorTest, TriggerToMissingSceneActivatesWithZeroActions)
+{
+    SceneStore::instance().bindTrigger(30, 2, 3, "deleted-scene");  // never created
+    Recorder rec;
+    MessageBus::publish(MessageBus::CentralSceneNotification{
+        .sourceNodeId = 30, .sequenceNumber = 1, .keyAttribute = 3, .sceneNumber = 2, .slowRefresh = false});
+    ASSERT_EQ(rec.log.size(), 1U);
+    EXPECT_EQ(rec.log[0], "scene:30:deleted-scene:0");  // activated, but no actions dispatched
+}


### PR DESCRIPTION
Closes #121 (scene-controller epic #119). The bus-only orchestrator that ties the scene store (#120) to inbound presses.

## What's in it
`src/orchestrator/SceneOrchestrator.cpp` — same pattern as WakeUpOrchestrator (prio 204, owns no thread, bus-only):
- Subscribes to the typed `CentralSceneNotification` (cc-translator, #22).
- Resolves `(sourceNodeId, sceneNumber, keyAttribute)` against the scene store's trigger table; on a hit, loads the scene and replays its actions as `SendDataCommand`s against the target nodes, then publishes `SceneActivated`.
- A press bound to nothing is a no-op; a trigger pointing at a deleted scene still reports `SceneActivated` with zero actions (logged).
- New manifest event **`SceneActivated{sourceNodeId, sceneNumber, keyAttribute, sceneId, actionCount}`** (orchestrator → external-api; the D-Bus signal that surfaces it is #122).

## Tests (4, bus-driven)
- Runs a bound scene's actions in order, then `SceneActivated`.
- **Context-dependent by source node** — same scene number from two senders runs different scenes (the FUTURE.md E2 headline).
- Unbound press is inert.
- Trigger → missing scene activates with zero actions.

## Verification
- Builds clean under **both** gnu (GCC 15) and llvm (Clang 20).
- `ctest` 292/292 pass.
- clang-format + clang-tidy clean.

End-to-end the closed loop now works at the daemon layer: a real Central Scene button (associated to the controller) → typed event → trigger lookup → SendData to target nodes. Remaining epic children: #122 (D-Bus CRUD to author scenes/triggers), #123 (terminal), #124 (extra trigger sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)