### PR TITLE
feat: D-Bus scene + trigger CRUD (#122)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -263,8 +263,11 @@ governs.
 ## Status / filed issues
 
 - **E2 (scene controller) is filed** as epic **#119** with children **#120**
-  (scene store), **#121** (SceneOrchestrator), **#122** (D-Bus CRUD), **#123**
-  (terminal), **#124** (extra trigger sources). E1/E3 remain exploratory here.
+  (scene store) ✅, **#121** (SceneOrchestrator) ✅, **#122** (D-Bus CRUD) ✅,
+  **#123** (terminal), **#124** (extra trigger sources). The store, orchestrator,
+  and D-Bus surface are merged; scenes run end-to-end over D-Bus today (see
+  MANUAL §16d). Remaining: terminal UI (#123) + extra trigger sources (#124).
+  E1/E3 remain exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).
   - "Scene controller thread" (#30) → **E2 / epic #119** (the old #30 stub should

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -1938,6 +1938,72 @@ dbus:
       action:
         custom: emitDeleteNodeMetadata
 
+    # ---- Scene + trigger CRUD (#122) ------------------------------
+    # Read/write the durable scene store (#120) over D-Bus. A *scene*
+    # crosses the wire as a(yay) — an ordered list of
+    # (targetNodeId, ccPayload) actions; a *trigger* as a(yyys) —
+    # (sourceNodeId, sceneNumber, keyAttribute, sceneId). The
+    # SceneOrchestrator (#121) consumes both at runtime; these methods
+    # only persist them, so the custom: handlers call
+    # SceneStore::instance() directly (state read/write, no bus command).
+
+    - name: SetScene
+      params:
+        - { name: sceneId, dbus: s,       cpp: string }
+        - { name: actions, dbus: "a(yay)", cpp: "list<SceneActionEntry>" }
+      # Custom: the actions a(yay) inbound array converts element-wise
+      # from sdbus::Struct<u8, ay> to SceneStore::Action.
+      action:
+        custom: emitSetScene
+
+    - name: GetScene
+      params:
+        - { name: sceneId, dbus: s, cpp: string }
+      returns:
+        type: list<SceneActionEntry>
+        dbus: a(yay)
+      action:
+        custom: emitGetScene
+
+    - name: DeleteScene
+      params:
+        - { name: sceneId, dbus: s, cpp: string }
+      action:
+        custom: emitDeleteScene
+
+    - name: ListScenes
+      params: []
+      returns:
+        type: list<string>
+        dbus: as
+      action:
+        custom: emitListScenes
+
+    - name: BindSceneTrigger
+      params:
+        - { name: sourceNodeId, dbus: y, cpp: u8 }
+        - { name: sceneNumber,  dbus: y, cpp: u8 }
+        - { name: keyAttribute, dbus: y, cpp: u8 }
+        - { name: sceneId,      dbus: s, cpp: string }
+      action:
+        custom: emitBindSceneTrigger
+
+    - name: UnbindSceneTrigger
+      params:
+        - { name: sourceNodeId, dbus: y, cpp: u8 }
+        - { name: sceneNumber,  dbus: y, cpp: u8 }
+        - { name: keyAttribute, dbus: y, cpp: u8 }
+      action:
+        custom: emitUnbindSceneTrigger
+
+    - name: ListSceneTriggers
+      params: []
+      returns:
+        type: list<SceneTriggerEntry>
+        dbus: a(yyys)
+      action:
+        custom: emitListSceneTriggers
+
   # ---- 3b. Signals ------------------------------------------------
   # Each signal is triggered by one or more MessageBus events. The
   # default mapping copies named fields straight through; CC-decoder
@@ -2293,6 +2359,16 @@ dbus:
         - { name: nodeId, dbus: y }
       triggered_by:
         event: NodeMetadataChanged
+
+    - name: SceneActivated
+      params:
+        - { name: sourceNodeId, dbus: y }
+        - { name: sceneNumber,  dbus: y }
+        - { name: keyAttribute, dbus: y }
+        - { name: sceneId,      dbus: s }
+        - { name: actionCount,  dbus: u }
+      triggered_by:
+        event: SceneActivated
 
 # =====================================================================
 # 4. Protocol modules

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1138,6 +1138,57 @@ busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
 # → a(ss)  1  "name" "Kitchen light"
 ```
 
+## 16d. Scene control (daemon-side scenes)
+
+The daemon runs **scenes** in response to physical button presses. A *scene*
+is an ordered list of **actions** — each a raw Command Class frame (the same
+bytes a `SendData` carries) addressed to a target node. A *trigger* binds a
+Central Scene press `(sourceNodeId, sceneNumber, keyAttribute)` to a scene id,
+so the same scene number from different controllers can run different scenes
+("scene 1" from the living room vs. the hallway). When a bound press arrives,
+the SceneOrchestrator replays the scene's actions and emits a `SceneActivated`
+signal. Stored in `nodes.db`, scoped per network.
+
+A scene crosses the wire as `a(yay)` — a list of `(targetNodeId, ccPayload)`
+structs; a trigger list as `a(yyys)`.
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `SetScene` | `(s a(yay)) → ()` | upsert scene `sceneId` with ordered actions |
+| `GetScene` | `(s) → (a(yay))` | the scene's actions; empty if no such scene |
+| `DeleteScene` | `(s) → ()` | remove a scene (dangling triggers become no-ops) |
+| `ListScenes` | `() → (as)` | all scene ids for the network, ascending |
+| `BindSceneTrigger` | `(y y y s) → ()` | sourceNodeId, sceneNumber, keyAttribute → sceneId |
+| `UnbindSceneTrigger` | `(y y y) → ()` | remove a press binding |
+| `ListSceneTriggers` | `() → (a(yyys))` | rows of (sourceNodeId, sceneNumber, keyAttribute, sceneId) |
+
+When a scene runs, the daemon emits `SceneActivated(y y y s u)` —
+`(sourceNodeId, sceneNumber, keyAttribute, sceneId, actionCount)`. A press that
+resolves to a deleted scene still fires `SceneActivated` with `actionCount = 0`;
+an unbound press fires nothing.
+
+Example — make a scene "tv" that turns node 5 on (`0x25 0x01 0xFF`) and node 6
+off (`0x25 0x01 0x00`), then run it from press 1× of scene 1 on controller 7:
+
+```bash
+# Define the scene: a(yay) = 2 actions
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 SetScene "sa(yay)" tv 2 \
+    5 3 0x25 0x01 0xFF \
+    6 3 0x25 0x01 0x00
+# Bind controller 7 / scene 1 / press 1x (keyAttribute 0) to it
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 BindSceneTrigger yyys 7 1 0 tv
+# Inspect
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 ListSceneTriggers
+# → a(yyys)  1  7 1 0 "tv"
+```
+
+(In the `SetScene` call each action is `targetNodeId`, then the `ay` payload as
+a length followed by its bytes — `5 3 0x25 0x01 0xFF` is "node 5, 3-byte
+payload `25 01 FF`".)
+
 ## 17. Future: ubus
 
 A second backend implementing the same methods/signals over OpenWrt's

--- a/scripts/codegen/targets/dbus_methods.py
+++ b/scripts/codegen/targets/dbus_methods.py
@@ -130,6 +130,8 @@ RETURN_TUPLE_ALIASES: dict[str, str] = {
     "GetDaemonError":     "DaemonErrorTuple",
     "ListDevicePolicies": "DevicePolicyTuple",
     "GetNodeMetadata":    "NodeMetadataTuple",
+    "GetScene":           "SceneActionEntry",
+    "ListSceneTriggers":  "SceneTriggerEntry",
 }
 
 

--- a/src/external-api/DBusBackend.cpp
+++ b/src/external-api/DBusBackend.cpp
@@ -4,6 +4,7 @@
 #include "../message-bus/MessageBus.hpp"
 #include "../node-metadata/NodeMetadata.hpp"
 #include "../policy-register/PolicyRegister.hpp"
+#include "../scene-store/SceneStore.hpp"
 #include "DBusBackendInternal.hpp"
 #include "Version.hpp"
 
@@ -463,5 +464,86 @@ auto emitGetNodeMetadata(DBusBackend::Impl& /*impl*/, std::uint8_t nodeId) -> st
 auto emitDeleteNodeMetadata(DBusBackend::Impl& /*impl*/, std::uint8_t nodeId, const std::string& key) -> void
 {
     NodeMetadata::instance().remove(nodeId, key);
+}
+
+// ---- Scene + trigger CRUD (#122) -------------------------------------
+// Thin adapters over SceneStore::instance(). A scene crosses the wire as
+// a(yay) — a list of (targetNodeId, ccPayload) actions; a trigger as
+// a(yyys). The store owns persistence only; the SceneOrchestrator (#121)
+// drives the runtime side off CentralSceneNotification, so nothing here
+// touches the bus.
+
+namespace
+{
+auto convertSceneActions(const std::vector<SceneActionEntry>& wire) -> std::vector<SceneStore::Action>
+{
+    std::vector<SceneStore::Action> out;
+    out.reserve(wire.size());
+    for (const auto& entry : wire)
+    {
+        out.push_back(SceneStore::Action{.targetNodeId = entry.get<0>(), .ccPayload = entry.get<1>()});
+    }
+    return out;
+}
+}  // namespace
+
+auto emitSetScene(DBusBackend::Impl& /*impl*/,
+                  const std::string& sceneId,
+                  const std::vector<SceneActionEntry>& actions) -> void
+{
+    SceneStore::instance().setScene(sceneId, convertSceneActions(actions));
+}
+
+auto emitGetScene(DBusBackend::Impl& /*impl*/, const std::string& sceneId) -> std::vector<SceneActionEntry>
+{
+    std::vector<SceneActionEntry> out;
+    const auto actions = SceneStore::instance().getScene(sceneId);
+    if (actions.has_value())
+    {
+        for (const auto& action : *actions)
+        {
+            out.emplace_back(action.targetNodeId, action.ccPayload);
+        }
+    }
+    return out;
+}
+
+auto emitDeleteScene(DBusBackend::Impl& /*impl*/, const std::string& sceneId) -> void
+{
+    SceneStore::instance().deleteScene(sceneId);
+}
+
+auto emitListScenes(DBusBackend::Impl& /*impl*/) -> std::vector<std::string>
+{
+    return SceneStore::instance().listScenes();
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
+auto emitBindSceneTrigger(DBusBackend::Impl& /*impl*/,
+                          std::uint8_t sourceNodeId,
+                          std::uint8_t sceneNumber,
+                          std::uint8_t keyAttribute,
+                          const std::string& sceneId) -> void
+{
+    SceneStore::instance().bindTrigger(sourceNodeId, sceneNumber, keyAttribute, sceneId);
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
+auto emitUnbindSceneTrigger(DBusBackend::Impl& /*impl*/,
+                            std::uint8_t sourceNodeId,
+                            std::uint8_t sceneNumber,
+                            std::uint8_t keyAttribute) -> void
+{
+    SceneStore::instance().unbindTrigger(sourceNodeId, sceneNumber, keyAttribute);
+}
+
+auto emitListSceneTriggers(DBusBackend::Impl& /*impl*/) -> std::vector<SceneTriggerEntry>
+{
+    std::vector<SceneTriggerEntry> out;
+    for (const auto& trigger : SceneStore::instance().listTriggers())
+    {
+        out.emplace_back(trigger.sourceNodeId, trigger.sceneNumber, trigger.keyAttribute, trigger.sceneId);
+    }
+    return out;
 }
 }  // namespace ExternalApi

--- a/src/external-api/DBusBackendInternal.hpp
+++ b/src/external-api/DBusBackendInternal.hpp
@@ -60,6 +60,15 @@ using DevicePolicyTuple = sdbus::Struct<std::uint16_t, std::uint16_t, std::uint1
 // One GetNodeMetadata row: (key, value). Matches the a(ss) return shape.
 using NodeMetadataTuple = sdbus::Struct<std::string, std::string>;
 
+// One scene action: (targetNodeId, ccPayload). The wire element of the
+// a(yay) scene shape — used both inbound (SetScene param) and outbound
+// (GetScene return). Custom handlers convert to/from SceneStore::Action.
+using SceneActionEntry = sdbus::Struct<std::uint8_t, std::vector<std::uint8_t>>;
+
+// One scene trigger: (sourceNodeId, sceneNumber, keyAttribute, sceneId).
+// Matches the a(yyys) ListSceneTriggers return shape.
+using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
+
 using DaemonErrorTuple = sdbus::Struct<std::uint8_t, std::string, std::uint8_t, std::string>;
 
 using NetworkStatusTuple = sdbus::Struct<bool,


### PR DESCRIPTION
Closes #122. Third child of the scene-controller epic #119 (after #120 scene store, #121 SceneOrchestrator — both merged).

## What
Exposes the durable scene store (#120) over D-Bus so operators can author scenes and bind them to physical presses at runtime. The SceneOrchestrator (#121) already runs scenes off `CentralSceneNotification`; this lands the read/write surface.

### Methods (`custom:` emit helpers → `SceneStore::instance()`)
| Method | Signature |
|--------|-----------|
| `SetScene` | `(s a(yay)) → ()` |
| `GetScene` | `(s) → (a(yay))` |
| `DeleteScene` | `(s) → ()` |
| `ListScenes` | `() → (as)` |
| `BindSceneTrigger` | `(y y y s) → ()` |
| `UnbindSceneTrigger` | `(y y y) → ()` |
| `ListSceneTriggers` | `() → (a(yyys))` |

### Signal
`SceneActivated(y y y s u)` — `(sourceNodeId, sceneNumber, keyAttribute, sceneId, actionCount)`, triggered by the existing `SceneActivated` bus event (added in #121).

## How
- A scene crosses the wire as `a(yay)` (list of `(targetNodeId, ccPayload)` actions); a trigger as `a(yyys)`.
- Two tuple aliases in `DBusBackendInternal.hpp` — `SceneActionEntry`, `SceneTriggerEntry` — give both the inbound `SetScene` param and the `GetScene`/`ListSceneTriggers` returns their wire shape (registered in `RETURN_TUPLE_ALIASES`).
- `convertSceneActions()` maps the inbound `a(yay)` element-wise to `SceneStore::Action`, mirroring `convertEndpointPairs` for Multi Channel Association.
- Manifest-driven: methods + signal declared in `InterfaceManifest.yml`; the codegen emits the registrations and forward-decls.

## Tests / verification
- gnu + llvm builds both green; `ctest` 292/292 pass.
- clang-format + clang-tidy clean (pre-commit hook passed).
- No dedicated backend-layer test — matches the PolicyRegister (#69) / NodeMetadata (#83) CRUD precedent; the storage logic is covered by the 10 SceneStore tests (#120) and the emit helpers are thin pass-throughs.

## Docs
- MANUAL §16d documents the methods + `busctl` examples.
- FUTURE.md marks epic #119 children #120/#121/#122 done; remaining: #123 (terminal UI), #124 (extra trigger sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)