### PR TITLE
feat: zwave-terminal scene + trigger management UI (#123)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -264,9 +264,10 @@ governs.
 
 - **E2 (scene controller) is filed** as epic **#119** with children **#120**
   (scene store) ✅, **#121** (SceneOrchestrator) ✅, **#122** (D-Bus CRUD) ✅,
-  **#123** (terminal), **#124** (extra trigger sources). The store, orchestrator,
-  and D-Bus surface are merged; scenes run end-to-end over D-Bus today (see
-  MANUAL §16d). Remaining: terminal UI (#123) + extra trigger sources (#124).
+  **#123** (terminal UI) ✅, **#124** (extra trigger sources). The store,
+  orchestrator, D-Bus surface, and terminal authoring/observation UI are merged;
+  scenes run end-to-end today (see MANUAL §16d). Remaining: extra trigger
+  sources (#124 — Basic Set / Scene Activation 0x2B beyond Central Scene).
   E1/E3 remain exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1189,6 +1189,13 @@ busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
 a length followed by its bytes — `5 3 0x25 0x01 0xFF` is "node 5, 3-byte
 payload `25 01 FF`".)
 
+`zwave-terminal` drives all of this from the `[e]` **Scenes** submenu: `[l]`
+list scenes (with their actions), `[t]` list triggers, `[s]` set/edit a scene
+(prompts a scene id, then repeatedly asks for a target node + CC payload bytes
+until you leave the node blank), `[d]` delete a scene, `[b]` bind a trigger,
+`[u]` unbind one. When a scene runs, the `SceneActivated` signal lands in the
+activity pane — e.g. `SceneActivated node=7 scene=1 1x -> "tv" (2 actions)`.
+
 ## 17. Future: ubus
 
 A second backend implementing the same methods/signals over OpenWrt's

--- a/utils/zwave-terminal/handlers.cpp
+++ b/utils/zwave-terminal/handlers.cpp
@@ -6,6 +6,7 @@
 #include "policy_blob.hpp"
 #include "prompts.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <iomanip>
 #include <ios>
@@ -1087,6 +1088,224 @@ auto handleListDevicePolicies(sdbus::IProxy& proxy) -> void
                << static_cast<unsigned>(std::get<1>(row)) << " id=0x" << std::setw(4)
                << static_cast<unsigned>(std::get<2>(row)) << std::dec << ":";
         logPolicy(header.str(), std::get<3>(row));
+    }
+}
+
+// ---- Scene + trigger management (#123) -------------------------------
+// Author scenes (ordered SendData actions) and bind physical presses to
+// them over the #122 D-Bus surface. The SceneOrchestrator runs the scene
+// when a bound Central Scene press arrives; SceneActivated lands in the
+// activity pane (see signal_handlers).
+
+namespace
+{
+using SceneActionEntry  = sdbus::Struct<std::uint8_t, std::vector<std::uint8_t>>;
+using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
+
+// Render a raw CC payload as space-separated hex for the activity log.
+auto formatPayloadHex(const std::vector<std::uint8_t>& payload) -> std::string
+{
+    std::ostringstream stream;
+    for (std::size_t idx = 0; idx < payload.size(); ++idx)
+    {
+        if (idx != 0)
+        {
+            stream << ' ';
+        }
+        stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(payload.at(idx));
+    }
+    return stream.str();
+}
+}  // namespace
+
+auto handleListScenes(sdbus::IProxy& proxy) -> void
+{
+    std::vector<std::string> scenes;
+    try
+    {
+        proxy.callMethod("ListScenes").onInterface(IFACE_NAME).storeResultsTo(scenes);
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"ListScenes failed: "} + err.what());
+        return;
+    }
+    if (scenes.empty())
+    {
+        logLine("Scenes: (none)");
+        return;
+    }
+    logLine("Scenes (" + std::to_string(scenes.size()) + "):");
+    for (const auto& sceneId : scenes)
+    {
+        std::vector<SceneActionEntry> actions;
+        try
+        {
+            proxy.callMethod("GetScene").onInterface(IFACE_NAME).withArguments(sceneId).storeResultsTo(actions);
+        }
+        catch (const sdbus::Error& err)
+        {
+            logLine("  \"" + sceneId + "\": GetScene failed: " + err.what());
+            continue;
+        }
+        logLine("  \"" + sceneId + "\" (" + std::to_string(actions.size()) + " action" +
+                (actions.size() == 1 ? "" : "s") + "):");
+        for (const auto& action : actions)
+        {
+            logLine("    -> node " + std::to_string(static_cast<unsigned>(std::get<0>(action))) + ": " +
+                    formatPayloadHex(std::get<1>(action)));
+        }
+    }
+}
+
+auto handleListSceneTriggers(sdbus::IProxy& proxy) -> void
+{
+    std::vector<SceneTriggerEntry> triggers;
+    try
+    {
+        proxy.callMethod("ListSceneTriggers").onInterface(IFACE_NAME).storeResultsTo(triggers);
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"ListSceneTriggers failed: "} + err.what());
+        return;
+    }
+    if (triggers.empty())
+    {
+        logLine("Scene triggers: (none)");
+        return;
+    }
+    logLine("Scene triggers (" + std::to_string(triggers.size()) + "):");
+    for (const auto& trigger : triggers)
+    {
+        const std::uint8_t keyAttribute = std::get<2>(trigger);
+        std::ostringstream stream;
+        stream << "  node " << static_cast<unsigned>(std::get<0>(trigger)) << " scene "
+               << static_cast<unsigned>(std::get<1>(trigger)) << " ";
+        if (const char* name = centralSceneKeyName(keyAttribute); name != nullptr)
+        {
+            stream << name;
+        }
+        else
+        {
+            stream << "key=" << static_cast<unsigned>(keyAttribute);
+        }
+        stream << " -> \"" << std::get<3>(trigger) << "\"";
+        logLine(stream.str());
+    }
+}
+
+auto handleSetScene(sdbus::IProxy& proxy) -> void
+{
+    auto sceneId = promptLine("Scene id:");
+    if (!sceneId.has_value())
+    {
+        logLine("SetScene: cancelled or empty scene id");
+        return;
+    }
+    std::vector<SceneActionEntry> actions;
+    while (true)
+    {
+        auto targetNode = promptNodeId("Action target node (blank to finish):");
+        if (!targetNode.has_value())
+        {
+            break;
+        }
+        auto payload = promptByteList("CC payload bytes (e.g. 0x25 0x01 0xFF):");
+        if (!payload.has_value())
+        {
+            logLine("SetScene: invalid payload — action skipped");
+            continue;
+        }
+        actions.emplace_back(*targetNode, *payload);
+    }
+    if (actions.empty())
+    {
+        logLine("SetScene: no actions entered — aborted");
+        return;
+    }
+    try
+    {
+        proxy.callMethod("SetScene").onInterface(IFACE_NAME).withArguments(*sceneId, actions);
+        logLine("SetScene \"" + *sceneId + "\" with " + std::to_string(actions.size()) + " action" +
+                (actions.size() == 1 ? "" : "s"));
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"SetScene failed: "} + err.what());
+    }
+}
+
+auto handleDeleteScene(sdbus::IProxy& proxy) -> void
+{
+    auto sceneId = promptLine("Scene id to delete:");
+    if (!sceneId.has_value())
+    {
+        logLine("DeleteScene: cancelled or empty scene id");
+        return;
+    }
+    try
+    {
+        proxy.callMethod("DeleteScene").onInterface(IFACE_NAME).withArguments(*sceneId);
+        logLine("DeleteScene \"" + *sceneId + "\"");
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"DeleteScene failed: "} + err.what());
+    }
+}
+
+auto handleBindSceneTrigger(sdbus::IProxy& proxy) -> void
+{
+    auto sourceNode   = promptNodeId("Source node (controller pressing the button):");
+    auto sceneNumber  = promptByte("Scene number (1-255):", 1, BYTE_MAX);
+    auto keyAttribute = promptByte("Key attribute (0=1x,1=release,2=hold,3=2x,4=3x):", 0, BYTE_MAX);
+    if (!sourceNode.has_value() || !sceneNumber.has_value() || !keyAttribute.has_value())
+    {
+        logLine("BindSceneTrigger: cancelled or invalid input");
+        return;
+    }
+    auto sceneId = promptLine("Scene id to bind to:");
+    if (!sceneId.has_value())
+    {
+        logLine("BindSceneTrigger: cancelled or empty scene id");
+        return;
+    }
+    try
+    {
+        proxy.callMethod("BindSceneTrigger")
+            .onInterface(IFACE_NAME)
+            .withArguments(*sourceNode, *sceneNumber, *keyAttribute, *sceneId);
+        logLine("BindSceneTrigger node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
+                " scene=" + std::to_string(static_cast<unsigned>(*sceneNumber)) + " -> \"" + *sceneId + "\"");
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"BindSceneTrigger failed: "} + err.what());
+    }
+}
+
+auto handleUnbindSceneTrigger(sdbus::IProxy& proxy) -> void
+{
+    auto sourceNode   = promptNodeId("Source node:");
+    auto sceneNumber  = promptByte("Scene number (1-255):", 1, BYTE_MAX);
+    auto keyAttribute = promptByte("Key attribute (0-4):", 0, BYTE_MAX);
+    if (!sourceNode.has_value() || !sceneNumber.has_value() || !keyAttribute.has_value())
+    {
+        logLine("UnbindSceneTrigger: cancelled or invalid input");
+        return;
+    }
+    try
+    {
+        proxy.callMethod("UnbindSceneTrigger")
+            .onInterface(IFACE_NAME)
+            .withArguments(*sourceNode, *sceneNumber, *keyAttribute);
+        logLine("UnbindSceneTrigger node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
+                " scene=" + std::to_string(static_cast<unsigned>(*sceneNumber)));
+    }
+    catch (const sdbus::Error& err)
+    {
+        logLine(std::string{"UnbindSceneTrigger failed: "} + err.what());
     }
 }
 

--- a/utils/zwave-terminal/handlers.hpp
+++ b/utils/zwave-terminal/handlers.hpp
@@ -53,6 +53,12 @@ auto handleDeleteNodeOverride(sdbus::IProxy& proxy) -> void;
 auto handleSetNodeOverrideEntry(sdbus::IProxy& proxy) -> void;
 auto handleDevicePolicyEdit(sdbus::IProxy& proxy) -> void;
 auto handleListDevicePolicies(sdbus::IProxy& proxy) -> void;
+auto handleListScenes(sdbus::IProxy& proxy) -> void;
+auto handleListSceneTriggers(sdbus::IProxy& proxy) -> void;
+auto handleSetScene(sdbus::IProxy& proxy) -> void;
+auto handleDeleteScene(sdbus::IProxy& proxy) -> void;
+auto handleBindSceneTrigger(sdbus::IProxy& proxy) -> void;
+auto handleUnbindSceneTrigger(sdbus::IProxy& proxy) -> void;
 }  // namespace zwt
 
 #endif  // ZWAVE_TERMINAL_HANDLERS_HPP

--- a/utils/zwave-terminal/main.cpp
+++ b/utils/zwave-terminal/main.cpp
@@ -192,6 +192,18 @@ auto run() -> int
                                   {'a', "Device policy authoring", [&] { handleDevicePolicyEdit(*proxy); }},
                               });
             }
+            else if (key == 'e' || key == 'E')
+            {
+                runActionMenu("Scenes",
+                              {
+                                  {'l', "List scenes", [&] { handleListScenes(*proxy); }},
+                                  {'t', "List triggers", [&] { handleListSceneTriggers(*proxy); }},
+                                  {'s', "Set / edit scene", [&] { handleSetScene(*proxy); }},
+                                  {'d', "Delete scene", [&] { handleDeleteScene(*proxy); }},
+                                  {'b', "Bind trigger (press -> scene)", [&] { handleBindSceneTrigger(*proxy); }},
+                                  {'u', "Unbind trigger", [&] { handleUnbindSceneTrigger(*proxy); }},
+                              });
+            }
             else if (key == 'l')
             {
                 handleListNodes(*proxy);

--- a/utils/zwave-terminal/prompts.cpp
+++ b/utils/zwave-terminal/prompts.cpp
@@ -232,4 +232,42 @@ auto promptNodeList(const char* label) -> std::optional<std::vector<std::uint8_t
     }
     return members;
 }
+
+/// Parse a space/comma-separated list of bytes (each 0..255, decimal or
+/// `0x`-prefixed hex) — e.g. a raw Command Class payload like
+/// `0x25 0x01 0xFF`. Requires at least one byte. nullopt on any malformed
+/// or out-of-range token. Reuses parseUint for per-token parsing so the
+/// 0x-prefix handling stays in one place.
+auto promptByteList(const char* label) -> std::optional<std::vector<std::uint8_t>>
+{
+    auto text = promptLine(label);
+    if (!text.has_value())
+    {
+        return std::nullopt;
+    }
+    for (auto& character : *text)
+    {
+        if (character == ',')
+        {
+            character = ' ';
+        }
+    }
+    std::istringstream stream(*text);
+    std::vector<std::uint8_t> bytes;
+    std::string token;
+    while (stream >> token)
+    {
+        const auto value = parseUint(token, static_cast<std::uint32_t>(BYTE_MAX));
+        if (!value.has_value())
+        {
+            return std::nullopt;
+        }
+        bytes.push_back(static_cast<std::uint8_t>(*value));
+    }
+    if (bytes.empty())
+    {
+        return std::nullopt;
+    }
+    return bytes;
+}
 }  // namespace zwt

--- a/utils/zwave-terminal/prompts.hpp
+++ b/utils/zwave-terminal/prompts.hpp
@@ -21,6 +21,7 @@ namespace zwt
 [[nodiscard]] auto promptU32(const char* label) -> std::optional<std::uint32_t>;
 [[nodiscard]] auto promptChar(const char* label, const std::string& valid) -> std::optional<char>;
 [[nodiscard]] auto promptNodeList(const char* label) -> std::optional<std::vector<std::uint8_t>>;
+[[nodiscard]] auto promptByteList(const char* label) -> std::optional<std::vector<std::uint8_t>>;
 }  // namespace zwt
 
 #endif  // ZWAVE_TERMINAL_PROMPTS_HPP

--- a/utils/zwave-terminal/render.cpp
+++ b/utils/zwave-terminal/render.cpp
@@ -96,7 +96,7 @@ auto draw(std::uint8_t lastSession) -> void
 
     mvprintw(row++, 0, "  [1] Add zwave node          [2] Remove zwave node");
     mvprintw(row++, 0, "  [g] Get from node…          [c] Control / set on node…");
-    mvprintw(row++, 0, "  [p] Policy…");
+    mvprintw(row++, 0, "  [p] Policy…                 [e] Scenes…");
     mvprintw(row++, 0, "  [l] List included nodes     [n] Network status     [i] Dongle info");
     mvprintw(row++, 0, "  [f] Remove failed node      [L] Set lifeline (controller -> group 1)");
     mvprintw(row++, 0, "  [s] Stop current operation (session %u)", static_cast<unsigned>(lastSession));

--- a/utils/zwave-terminal/signal_handlers.cpp
+++ b/utils/zwave-terminal/signal_handlers.cpp
@@ -162,6 +162,31 @@ auto registerSignalHandlers(sdbus::IProxy& proxy) -> void
                 logLine(stream.str());
             });
 
+    proxy.uponSignal("SceneActivated")
+        .onInterface(IFACE_NAME)
+        .call(
+            [](std::uint8_t sourceNodeId,
+               std::uint8_t sceneNumber,
+               std::uint8_t keyAttribute,
+               const std::string& sceneId,
+               std::uint32_t actionCount) -> void
+            {
+                std::ostringstream stream;
+                stream << "SceneActivated node=" << static_cast<unsigned>(sourceNodeId)
+                       << " scene=" << static_cast<unsigned>(sceneNumber) << " ";
+                if (const char* name = centralSceneKeyName(keyAttribute); name != nullptr)
+                {
+                    stream << name;
+                }
+                else
+                {
+                    stream << "key=" << static_cast<unsigned>(keyAttribute);
+                }
+                stream << " -> \"" << sceneId << "\" (" << actionCount << " action" << (actionCount == 1 ? "" : "s")
+                       << ")";
+                logLine(stream.str());
+            });
+
     proxy.uponSignal("DoorLockOperationReport")
         .onInterface(IFACE_NAME)
         .call(


### PR DESCRIPTION
Closes #123. Fourth child of the scene-controller epic #119 (after #120 store, #121 orchestrator, #122 D-Bus CRUD — all merged).

## What
Adds a `[e]` **Scenes** submenu to `zwave-terminal` so an operator can author and observe daemon-side scenes over the #122 D-Bus surface, without `busctl`:

| Key | Action |
|-----|--------|
| `[l]` | List scenes (with each scene's actions, rendered as hex) |
| `[t]` | List triggers (key attribute resolved via `centralSceneKeyName`) |
| `[s]` | Set / edit a scene |
| `[d]` | Delete a scene |
| `[b]` | Bind a trigger (press → scene) |
| `[u]` | Unbind a trigger |

`SetScene` authoring loops: prompt a scene id, then repeatedly ask for a target node + raw CC payload bytes until the node is left blank.

## How
- New `promptByteList` prompt — space/comma-separated bytes, decimal or `0x`-prefixed hex, each `0..255` (reuses `parseUint` for the per-token 0x handling). Used for the CC payload of each scene action.
- Handlers use the `a(yay)` / `a(yyys)` tuple shapes (`SceneActionEntry` / `SceneTriggerEntry`, mirroring the daemon-side aliases) and follow the existing policy-CRUD handler pattern (`logLine` outcomes, `sdbus::Error` guards).
- The `SceneActivated` signal is now subscribed in `signal_handlers.cpp` and rendered in the activity pane — e.g. `SceneActivated node=7 scene=1 1x -> "tv" (2 actions)` — reusing `centralSceneKeyName` like `CentralSceneNotification`.
- Menu legend gains `[e] Scenes…` next to `[p] Policy…`.

## Tests / verification
- gnu + llvm builds both green (terminal included); `ctest` 292/292 pass (terminal is a TUI util with no unit tests — matches the existing convention).
- clang-format + clang-tidy clean on all changed files (pre-commit hook passed).

## Docs
- MANUAL §16d gains a paragraph documenting the `[e]` submenu + the `SceneActivated` activity-pane line.
- FUTURE.md marks epic #119 child #123 done; only #124 (extra trigger sources — Basic Set / Scene Activation 0x2B) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)