### PR TITLE
feat: scene triggers from Basic Set + Scene Activation (#124)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -262,13 +262,12 @@ governs.
 
 ## Status / filed issues
 
-- **E2 (scene controller) is filed** as epic **#119** with children **#120**
-  (scene store) ✅, **#121** (SceneOrchestrator) ✅, **#122** (D-Bus CRUD) ✅,
-  **#123** (terminal UI) ✅, **#124** (extra trigger sources). The store,
-  orchestrator, D-Bus surface, and terminal authoring/observation UI are merged;
-  scenes run end-to-end today (see MANUAL §16d). Remaining: extra trigger
-  sources (#124 — Basic Set / Scene Activation 0x2B beyond Central Scene).
-  E1/E3 remain exploratory here.
+- **E2 (scene controller) is complete** — epic **#119** with all children
+  merged: **#120** (scene store) ✅, **#121** (SceneOrchestrator) ✅, **#122**
+  (D-Bus CRUD) ✅, **#123** (terminal UI) ✅, **#124** (extra trigger sources:
+  Basic Set 0x20 + Scene Activation 0x2B, behind a `source` discriminator) ✅.
+  Scenes run end-to-end from Central Scene, Basic Set, or Scene Activation
+  presses (see MANUAL §16d). E1/E3 remain exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).
   - "Scene controller thread" (#30) → **E2 / epic #119** (the old #30 stub should

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -812,6 +812,37 @@ events:
       - { name: sceneNumber,    type: u8,   default: 0 }
       - { name: slowRefresh,    type: bool, default: false }
 
+  - name: BasicSetReceived
+    category: transient
+    direction: { publishers: [cc-translator], subscribers: [external-api, orchestrator] }
+    doc: |
+      A node sent us a Basic (CC 0x20) Set — the way many non-scene
+      controllers (PIR sensors, simple wall switches) address their
+      association target. Push-only: republished by the cc-translator from
+      inbound ApplicationCommand frames whose ccData parses as a Basic Set.
+      `value`: 0x00 off/inactive, 0xFF on/active, 0x01..0x63 a level. The
+      SceneOrchestrator (#124) keys scene triggers on (sourceNodeId, value).
+    fields:
+      - { name: sourceNodeId, type: u8, default: 0 }
+      - { name: value,        type: u8, default: 0 }
+
+  - name: SceneActivationSet
+    category: transient
+    direction: { publishers: [cc-translator], subscribers: [external-api, orchestrator] }
+    doc: |
+      A node sent us a Scene Activation (CC 0x2B) Set — a scene controller
+      announcing "scene N is now active". Push-only: republished by the
+      cc-translator from inbound ApplicationCommand frames whose ccData
+      parses as a Scene Activation Set. `sceneId` is the activated scene
+      number (1..255); `dimmingDuration` is the requested transition time
+      (0x00 instant, 0x01..0x7F seconds, 0x80..0xFE minutes, 0xFF default).
+      The SceneOrchestrator (#124) keys scene triggers on (sourceNodeId,
+      sceneId).
+    fields:
+      - { name: sourceNodeId,    type: u8, default: 0 }
+      - { name: sceneId,         type: u8, default: 0 }
+      - { name: dimmingDuration, type: u8, default: 0 }
+
   - name: DoorLockOperationReport
     category: transient
     direction: { publishers: [cc-translator], subscribers: [external-api] }
@@ -1979,17 +2010,24 @@ dbus:
       action:
         custom: emitListScenes
 
+    # `source` discriminates the trigger source CC so the same
+    # (node, selector) can't collide across sources: 0 Central Scene
+    # (selector = sceneNumber, keyAttribute meaningful), 1 Basic Set
+    # (selector = value, keyAttribute 0), 2 Scene Activation
+    # (selector = sceneId, keyAttribute 0). See #124 / MANUAL §16d.
     - name: BindSceneTrigger
       params:
+        - { name: source,       dbus: y, cpp: u8, doc: "0 Central Scene, 1 Basic Set, 2 Scene Activation" }
         - { name: sourceNodeId, dbus: y, cpp: u8 }
-        - { name: sceneNumber,  dbus: y, cpp: u8 }
-        - { name: keyAttribute, dbus: y, cpp: u8 }
+        - { name: sceneNumber,  dbus: y, cpp: u8, doc: "selector: scene/value/sceneId per source" }
+        - { name: keyAttribute, dbus: y, cpp: u8, doc: "Central Scene key attribute; 0 for other sources" }
         - { name: sceneId,      dbus: s, cpp: string }
       action:
         custom: emitBindSceneTrigger
 
     - name: UnbindSceneTrigger
       params:
+        - { name: source,       dbus: y, cpp: u8 }
         - { name: sourceNodeId, dbus: y, cpp: u8 }
         - { name: sceneNumber,  dbus: y, cpp: u8 }
         - { name: keyAttribute, dbus: y, cpp: u8 }
@@ -2000,7 +2038,7 @@ dbus:
       params: []
       returns:
         type: list<SceneTriggerEntry>
-        dbus: a(yyys)
+        dbus: a(yyyys)
       action:
         custom: emitListSceneTriggers
 
@@ -2147,6 +2185,21 @@ dbus:
         - { name: slowRefresh,    dbus: b, doc: "v2+ slow-refresh flag for held keys" }
       triggered_by:
         event: CentralSceneNotification
+
+    - name: BasicSetReceived
+      params:
+        - { name: sourceNodeId, dbus: y }
+        - { name: value,        dbus: y, doc: "0x00 off, 0xFF on, 0x01..0x63 level" }
+      triggered_by:
+        event: BasicSetReceived
+
+    - name: SceneActivationSet
+      params:
+        - { name: sourceNodeId,    dbus: y }
+        - { name: sceneId,         dbus: y, doc: "activated scene number 1..255" }
+        - { name: dimmingDuration, dbus: y, doc: "0 instant, 1..0x7F sec, 0x80..0xFE min, 0xFF default" }
+      triggered_by:
+        event: SceneActivationSet
 
     - name: DoorLockOperationReport
       params:
@@ -2524,6 +2577,24 @@ modules:
           - { name: keyAttribute,   type: u8,   doc: "0 press1x, 1 release, 2 hold, 3 press2x, …" }
           - { name: sceneNumber,    type: u8 }
           - { name: slowRefresh,    type: bool, doc: "v2+ slow-refresh flag (bit 7 of properties)" }
+
+  - name: SceneActivation
+    wire:
+      class_byte: 0x2B
+      prefix: SCENE_ACTIVATION
+    description: |
+      Push-only scene events from controllers that announce "scene N is
+      now active" via SCENE_ACTIVATION_SET (0x01). The daemon never sends
+      Scene Activation frames — it only decodes the inbound SET into a
+      typed signal the SceneOrchestrator (#124) keys triggers on. The
+      decode lives in the hand-written SceneActivation.cpp.
+    commands:
+      - name: Set
+        wire:
+          byte: 0x01
+        decoded_struct:
+          - { name: sceneId,         type: u8, doc: "activated scene number 1..255" }
+          - { name: dimmingDuration, type: u8, doc: "0 instant, 1..0x7F sec, 0x80..0xFE min, 0xFF default" }
 
   - name: DoorLock
     wire:
@@ -3205,6 +3276,27 @@ translations:
       keyAttribute:   decoded.keyAttribute
       sceneNumber:    decoded.sceneNumber
       slowRefresh:    decoded.slowRefresh
+
+  - publishes: BasicSetReceived
+    triggered_by: ApplicationCommand
+    decode:
+      codec: Basic.decodeSet
+      input: ccData
+      on_none: skip
+    map:
+      sourceNodeId: event.sourceNodeId
+      value:        decoded.value
+
+  - publishes: SceneActivationSet
+    triggered_by: ApplicationCommand
+    decode:
+      codec: SceneActivation.decodeSet
+      input: ccData
+      on_none: skip
+    map:
+      sourceNodeId:    event.sourceNodeId
+      sceneId:         decoded.sceneId
+      dimmingDuration: decoded.dimmingDuration
 
   - publishes: DoorLockOperationReport
     triggered_by: ApplicationCommand

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1143,14 +1143,27 @@ busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
 The daemon runs **scenes** in response to physical button presses. A *scene*
 is an ordered list of **actions** — each a raw Command Class frame (the same
 bytes a `SendData` carries) addressed to a target node. A *trigger* binds a
-Central Scene press `(sourceNodeId, sceneNumber, keyAttribute)` to a scene id,
-so the same scene number from different controllers can run different scenes
-("scene 1" from the living room vs. the hallway). When a bound press arrives,
-the SceneOrchestrator replays the scene's actions and emits a `SceneActivated`
-signal. Stored in `nodes.db`, scoped per network.
+physical press to a scene id, so the same selector from different controllers
+can run different scenes ("scene 1" from the living room vs. the hallway). When
+a bound press arrives, the SceneOrchestrator replays the scene's actions and
+emits a `SceneActivated` signal. Stored in `nodes.db`, scoped per network.
 
 A scene crosses the wire as `a(yay)` — a list of `(targetNodeId, ccPayload)`
-structs; a trigger list as `a(yyys)`.
+structs; a trigger list as `a(yyyys)`.
+
+**Trigger sources.** A trigger's leading `source` byte selects which Command
+Class the press arrives on (#124). The `sceneNumber` field is reinterpreted as
+a per-source *selector*, and `keyAttribute` is only meaningful for Central
+Scene:
+
+| `source` | CC | selector (`sceneNumber`) | `keyAttribute` |
+|----------|----|--------------------------|----------------|
+| `0` | Central Scene (0x5B) | scene number | press 1×/2×/hold/… |
+| `1` | Basic Set (0x20) | Basic value (0/0xFF/level) | 0 (ignored) |
+| `2` | Scene Activation (0x2B) | activation scene id | 0 (ignored) |
+
+The `source` is part of the trigger key, so the same `(node, selector)` can be
+bound independently on each source without colliding.
 
 | Method | Signature | Notes |
 |--------|-----------|-------|
@@ -1158,17 +1171,22 @@ structs; a trigger list as `a(yyys)`.
 | `GetScene` | `(s) → (a(yay))` | the scene's actions; empty if no such scene |
 | `DeleteScene` | `(s) → ()` | remove a scene (dangling triggers become no-ops) |
 | `ListScenes` | `() → (as)` | all scene ids for the network, ascending |
-| `BindSceneTrigger` | `(y y y s) → ()` | sourceNodeId, sceneNumber, keyAttribute → sceneId |
-| `UnbindSceneTrigger` | `(y y y) → ()` | remove a press binding |
-| `ListSceneTriggers` | `() → (a(yyys))` | rows of (sourceNodeId, sceneNumber, keyAttribute, sceneId) |
+| `BindSceneTrigger` | `(y y y y s) → ()` | source, sourceNodeId, selector, keyAttribute → sceneId |
+| `UnbindSceneTrigger` | `(y y y y) → ()` | remove a press binding |
+| `ListSceneTriggers` | `() → (a(yyyys))` | rows of (source, sourceNodeId, selector, keyAttribute, sceneId) |
 
 When a scene runs, the daemon emits `SceneActivated(y y y s u)` —
-`(sourceNodeId, sceneNumber, keyAttribute, sceneId, actionCount)`. A press that
-resolves to a deleted scene still fires `SceneActivated` with `actionCount = 0`;
-an unbound press fires nothing.
+`(sourceNodeId, sceneNumber, keyAttribute, sceneId, actionCount)` (for Basic /
+Scene Activation triggers `sceneNumber` carries the selector and `keyAttribute`
+is 0). A press that resolves to a deleted scene still fires `SceneActivated`
+with `actionCount = 0`; an unbound press fires nothing. The two non-Central
+sources also surface as their own observability signals — `BasicSetReceived(y
+y)` and `SceneActivationSet(y y y)` — fired whenever such a frame arrives,
+whether or not it's bound to a scene.
 
 Example — make a scene "tv" that turns node 5 on (`0x25 0x01 0xFF`) and node 6
-off (`0x25 0x01 0x00`), then run it from press 1× of scene 1 on controller 7:
+off (`0x25 0x01 0x00`), then run it from press 1× of scene 1 on Central Scene
+controller 7:
 
 ```bash
 # Define the scene: a(yay) = 2 actions
@@ -1176,13 +1194,16 @@ busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
     com.tiunda.ZWaved1 SetScene "sa(yay)" tv 2 \
     5 3 0x25 0x01 0xFF \
     6 3 0x25 0x01 0x00
-# Bind controller 7 / scene 1 / press 1x (keyAttribute 0) to it
+# Bind source 0 (Central Scene), controller 7, scene 1, press 1x (key 0)
 busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
-    com.tiunda.ZWaved1 BindSceneTrigger yyys 7 1 0 tv
+    com.tiunda.ZWaved1 BindSceneTrigger yyyys 0 7 1 0 tv
+# Bind the same scene to a Basic Set "on" (0xFF=255) from node 8 (source 1)
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 BindSceneTrigger yyyys 1 8 255 0 tv
 # Inspect
 busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
     com.tiunda.ZWaved1 ListSceneTriggers
-# → a(yyys)  1  7 1 0 "tv"
+# → a(yyyys)  2  0 7 1 0 "tv"  1 8 255 0 "tv"
 ```
 
 (In the `SetScene` call each action is `targetNodeId`, then the `ay` payload as
@@ -1190,11 +1211,14 @@ a length followed by its bytes — `5 3 0x25 0x01 0xFF` is "node 5, 3-byte
 payload `25 01 FF`".)
 
 `zwave-terminal` drives all of this from the `[e]` **Scenes** submenu: `[l]`
-list scenes (with their actions), `[t]` list triggers, `[s]` set/edit a scene
-(prompts a scene id, then repeatedly asks for a target node + CC payload bytes
-until you leave the node blank), `[d]` delete a scene, `[b]` bind a trigger,
-`[u]` unbind one. When a scene runs, the `SceneActivated` signal lands in the
-activity pane — e.g. `SceneActivated node=7 scene=1 1x -> "tv" (2 actions)`.
+list scenes (with their actions), `[t]` list triggers (tagged by source), `[s]`
+set/edit a scene (prompts a scene id, then repeatedly asks for a target node +
+CC payload bytes until you leave the node blank), `[d]` delete a scene, `[b]`
+bind a trigger (prompts the source kind first, then the source-appropriate
+selector), `[u]` unbind one. When a scene runs, the `SceneActivated` signal
+lands in the activity pane — e.g. `SceneActivated node=7 scene=1 1x -> "tv" (2
+actions)`; inbound `BasicSetReceived` / `SceneActivationSet` frames are logged
+there too.
 
 ## 17. Future: ubus
 

--- a/src/external-api/DBusBackend.cpp
+++ b/src/external-api/DBusBackend.cpp
@@ -520,21 +520,23 @@ auto emitListScenes(DBusBackend::Impl& /*impl*/) -> std::vector<std::string>
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
 auto emitBindSceneTrigger(DBusBackend::Impl& /*impl*/,
+                          std::uint8_t source,
                           std::uint8_t sourceNodeId,
                           std::uint8_t sceneNumber,
                           std::uint8_t keyAttribute,
                           const std::string& sceneId) -> void
 {
-    SceneStore::instance().bindTrigger(sourceNodeId, sceneNumber, keyAttribute, sceneId);
+    SceneStore::instance().bindTrigger(source, sourceNodeId, sceneNumber, keyAttribute, sceneId);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
 auto emitUnbindSceneTrigger(DBusBackend::Impl& /*impl*/,
+                            std::uint8_t source,
                             std::uint8_t sourceNodeId,
                             std::uint8_t sceneNumber,
                             std::uint8_t keyAttribute) -> void
 {
-    SceneStore::instance().unbindTrigger(sourceNodeId, sceneNumber, keyAttribute);
+    SceneStore::instance().unbindTrigger(source, sourceNodeId, sceneNumber, keyAttribute);
 }
 
 auto emitListSceneTriggers(DBusBackend::Impl& /*impl*/) -> std::vector<SceneTriggerEntry>
@@ -542,7 +544,8 @@ auto emitListSceneTriggers(DBusBackend::Impl& /*impl*/) -> std::vector<SceneTrig
     std::vector<SceneTriggerEntry> out;
     for (const auto& trigger : SceneStore::instance().listTriggers())
     {
-        out.emplace_back(trigger.sourceNodeId, trigger.sceneNumber, trigger.keyAttribute, trigger.sceneId);
+        out.emplace_back(
+            trigger.source, trigger.sourceNodeId, trigger.sceneNumber, trigger.keyAttribute, trigger.sceneId);
     }
     return out;
 }

--- a/src/external-api/DBusBackendInternal.hpp
+++ b/src/external-api/DBusBackendInternal.hpp
@@ -65,9 +65,10 @@ using NodeMetadataTuple = sdbus::Struct<std::string, std::string>;
 // (GetScene return). Custom handlers convert to/from SceneStore::Action.
 using SceneActionEntry = sdbus::Struct<std::uint8_t, std::vector<std::uint8_t>>;
 
-// One scene trigger: (sourceNodeId, sceneNumber, keyAttribute, sceneId).
-// Matches the a(yyys) ListSceneTriggers return shape.
-using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
+// One scene trigger: (source, sourceNodeId, sceneNumber, keyAttribute,
+// sceneId). Matches the a(yyyys) ListSceneTriggers return shape. `source`
+// is the SceneStore SOURCE_* discriminator (#124).
+using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
 
 using DaemonErrorTuple = sdbus::Struct<std::uint8_t, std::string, std::uint8_t, std::string>;
 

--- a/src/orchestrator/SceneOrchestrator.cpp
+++ b/src/orchestrator/SceneOrchestrator.cpp
@@ -1,18 +1,24 @@
-// SceneOrchestrator (#121) — runs daemon-side scenes from physical button
-// presses. A Central Scene controller (wall switch / remote) associated to
-// the controller node sends a CENTRAL_SCENE NOTIFICATION; the cc-translator
-// republishes it as the typed CentralSceneNotification bus event. This
-// orchestrator resolves the press `(sourceNodeId, sceneNumber, keyAttribute)`
-// against the scene store's trigger table (#120) and, on a hit, replays the
-// bound scene's actions as SendDataCommands against the target nodes — then
-// publishes SceneActivated for observers.
+// SceneOrchestrator (#121, #124) — runs daemon-side scenes from physical
+// presses on real controllers. The cc-translator republishes inbound frames
+// as typed bus events; this orchestrator resolves each against the scene
+// store's trigger table (#120) and, on a hit, replays the bound scene's
+// actions as SendDataCommands against the target nodes — then publishes
+// SceneActivated for observers.
+//
+// Three trigger sources are supported (#124), distinguished by the store's
+// `source` discriminator so the same (node, selector) can't collide:
+//   - Central Scene (0x5B) — CentralSceneNotification, keyed on
+//     (sourceNodeId, sceneNumber, keyAttribute)
+//   - Basic Set (0x20)     — BasicSetReceived, keyed on (sourceNodeId, value)
+//   - Scene Activation (0x2B) — SceneActivationSet, keyed on
+//     (sourceNodeId, sceneId)
 //
 // Loose-coupling rule (same as the other orchestrators): bus-only, owns no
 // thread, reacts synchronously to the bus event under the recursive bus
 // mutex; the SendDataCommand / SceneActivated events it publishes are
-// delivered depth-first before control returns to the cc-translator. The
-// `(sourceNodeId, sceneNumber, keyAttribute)` key is what lets the same scene
-// number from different senders run different scenes (FUTURE.md E2).
+// delivered depth-first before control returns to the cc-translator. Keying
+// on the source node is what lets the same selector from different senders
+// run different scenes (FUTURE.md E2).
 
 #include "../logger/Logger.hpp"
 #include "../message-bus/MessageBus.hpp"
@@ -33,7 +39,9 @@ constexpr std::uint8_t NO_CALLBACK = 0x00;
 // NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public member reads like a struct
 struct State
 {
-    MessageBus::SubscriptionGuard sceneSub;  // auto-unsubscribes on teardown
+    MessageBus::SubscriptionGuard sceneSub;            // Central Scene; auto-unsubscribes on teardown
+    MessageBus::SubscriptionGuard basicSub;            // Basic Set
+    MessageBus::SubscriptionGuard sceneActivationSub;  // Scene Activation
 
     State() = default;
     ~State()
@@ -54,10 +62,17 @@ auto state() -> State&
     return instance;
 }
 
-auto onCentralScene(const MessageBus::CentralSceneNotification& note) -> void
+// Resolve one press against the trigger table and, on a hit, replay the
+// bound scene's actions then publish SceneActivated. `sceneNumber` /
+// `keyAttribute` are the per-source selector fields (see SceneStore SOURCE_*).
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire fields, named at the call sites
+auto runScene(std::uint8_t source,
+              std::uint8_t sourceNodeId,
+              std::uint8_t sceneNumber,
+              std::uint8_t keyAttribute) -> void
 {
     const std::optional<std::string> sceneId =
-        SceneStore::instance().resolveTrigger(note.sourceNodeId, note.sceneNumber, note.keyAttribute);
+        SceneStore::instance().resolveTrigger(source, sourceNodeId, sceneNumber, keyAttribute);
     if (!sceneId.has_value())
     {
         return;  // press not bound to any scene — nothing to do
@@ -81,27 +96,47 @@ auto onCentralScene(const MessageBus::CentralSceneNotification& note) -> void
     {
         // A trigger pointing at a deleted scene — log it; the press is
         // still reported as activated with zero actions.
-        Logger::warn("[SceneOrchestrator] trigger for node " + std::to_string(note.sourceNodeId) +
+        Logger::warn("[SceneOrchestrator] trigger for node " + std::to_string(sourceNodeId) +
                      " resolved to missing scene '" + *sceneId + "'");
     }
 
     MessageBus::publish(MessageBus::SceneActivated{
-        .sourceNodeId = note.sourceNodeId,
-        .sceneNumber  = note.sceneNumber,
-        .keyAttribute = note.keyAttribute,
+        .sourceNodeId = sourceNodeId,
+        .sceneNumber  = sceneNumber,
+        .keyAttribute = keyAttribute,
         .sceneId      = *sceneId,
         .actionCount  = dispatched,
     });
 
-    Logger::info("[SceneOrchestrator] node " + std::to_string(note.sourceNodeId) + " scene " +
-                 std::to_string(note.sceneNumber) + " → '" + *sceneId + "' (" + std::to_string(dispatched) +
+    Logger::info("[SceneOrchestrator] source " + std::to_string(source) + " node " + std::to_string(sourceNodeId) +
+                 " selector " + std::to_string(sceneNumber) + " → '" + *sceneId + "' (" + std::to_string(dispatched) +
                  " action(s))");
+}
+
+auto onCentralScene(const MessageBus::CentralSceneNotification& note) -> void
+{
+    runScene(SceneStore::SOURCE_CENTRAL_SCENE, note.sourceNodeId, note.sceneNumber, note.keyAttribute);
+}
+
+auto onBasicSet(const MessageBus::BasicSetReceived& note) -> void
+{
+    // Basic Set has no key attribute; the value is the selector.
+    runScene(SceneStore::SOURCE_BASIC_SET, note.sourceNodeId, note.value, 0);
+}
+
+auto onSceneActivation(const MessageBus::SceneActivationSet& note) -> void
+{
+    // Scene Activation has no key attribute; the scene id is the selector.
+    runScene(SceneStore::SOURCE_SCENE_ACTIVATION, note.sourceNodeId, note.sceneId, 0);
 }
 
 __attribute__((constructor(CONFIG_ORCHESTRATOR_PRIO))) auto startSceneOrchestrator() -> void
 {
     state().sceneSub =
         MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::CentralSceneNotification>(onCentralScene));
+    state().basicSub = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::BasicSetReceived>(onBasicSet));
+    state().sceneActivationSub =
+        MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::SceneActivationSet>(onSceneActivation));
     Logger::info("[SceneOrchestrator] watching for scene presses");
 }
 }  // namespace

--- a/src/scene-store/SceneStore.cpp
+++ b/src/scene-store/SceneStore.cpp
@@ -26,20 +26,32 @@ constexpr const char* DEFAULT_STATE_DIR = "/var/lib/zwaved";
 constexpr const char* STATE_DIR_ENV     = "ZWAVED_STATE_DIR";
 constexpr const char* DB_FILENAME       = "nodes.db";
 
-constexpr const char* SCHEMA_SQL = R"(
+// Schema version stamped into PRAGMA user_version. v1 added the `source`
+// discriminator column to scene_triggers (#124); a v0 DB (created by #120,
+// before #124) is migrated in the constructor.
+constexpr int SCHEMA_VERSION = 1;
+
+constexpr const char* SCHEMA_SCENES_SQL = R"(
 CREATE TABLE IF NOT EXISTS scenes (
     home_id  TEXT NOT NULL,
     scene_id TEXT NOT NULL,
     actions  BLOB NOT NULL,
     PRIMARY KEY (home_id, scene_id)
 );
+)";
+
+// v1 trigger table: `source` (SOURCE_* discriminator) is part of the key so
+// Central Scene / Basic Set / Scene Activation triggers can share the same
+// (node, selector) without colliding.
+constexpr const char* SCHEMA_TRIGGERS_SQL = R"(
 CREATE TABLE IF NOT EXISTS scene_triggers (
     home_id        TEXT    NOT NULL,
+    source         INTEGER NOT NULL,
     source_node_id INTEGER NOT NULL,
     scene_number   INTEGER NOT NULL,
     key_attribute  INTEGER NOT NULL,
     scene_id       TEXT    NOT NULL,
-    PRIMARY KEY (home_id, source_node_id, scene_number, key_attribute)
+    PRIMARY KEY (home_id, source, source_node_id, scene_number, key_attribute)
 );
 )";
 
@@ -49,24 +61,37 @@ constexpr const char* DELETE_SCENE_SQL = "DELETE FROM scenes WHERE home_id = ? A
 constexpr const char* LIST_SCENES_SQL  = "SELECT scene_id FROM scenes WHERE home_id = ? ORDER BY scene_id ASC";
 
 constexpr const char* UPSERT_TRIGGER_SQL  = "INSERT OR REPLACE INTO scene_triggers "
-                                            "(home_id, source_node_id, scene_number, key_attribute, scene_id) "
-                                            "VALUES (?, ?, ?, ?, ?)";
-constexpr const char* DELETE_TRIGGER_SQL  = "DELETE FROM scene_triggers WHERE home_id = ? AND source_node_id = ? "
-                                            "AND scene_number = ? AND key_attribute = ?";
-constexpr const char* RESOLVE_TRIGGER_SQL = "SELECT scene_id FROM scene_triggers WHERE home_id = ? "
+                                            "(home_id, source, source_node_id, scene_number, key_attribute, scene_id) "
+                                            "VALUES (?, ?, ?, ?, ?, ?)";
+constexpr const char* DELETE_TRIGGER_SQL  = "DELETE FROM scene_triggers WHERE home_id = ? AND source = ? "
                                             "AND source_node_id = ? AND scene_number = ? AND key_attribute = ?";
-constexpr const char* LIST_TRIGGERS_SQL   = "SELECT source_node_id, scene_number, key_attribute, scene_id "
+constexpr const char* RESOLVE_TRIGGER_SQL = "SELECT scene_id FROM scene_triggers WHERE home_id = ? AND source = ? "
+                                            "AND source_node_id = ? AND scene_number = ? AND key_attribute = ?";
+constexpr const char* LIST_TRIGGERS_SQL   = "SELECT source, source_node_id, scene_number, key_attribute, scene_id "
                                             "FROM scene_triggers WHERE home_id = ? "
-                                            "ORDER BY source_node_id ASC, scene_number ASC, key_attribute ASC";
+                                            "ORDER BY source ASC, source_node_id ASC, scene_number ASC, "
+                                            "key_attribute ASC";
 
-// 1-based bind positions for the 5-column trigger upsert (named so the 5th
-// stays out of the magic-number checker; positions 1-4 are small enough to
-// be left as literals in the other statements).
+// v0 -> v1 migration: copy legacy rows (Central Scene only) into the v1
+// table, stamping source = SOURCE_CENTRAL_SCENE (0).
+constexpr const char* MIGRATE_RENAME_SQL = "ALTER TABLE scene_triggers RENAME TO scene_triggers_legacy";
+constexpr const char* MIGRATE_COPY_SQL =
+    "INSERT OR IGNORE INTO scene_triggers (home_id, source, source_node_id, scene_number, key_attribute, scene_id) "
+    "SELECT home_id, 0, source_node_id, scene_number, key_attribute, scene_id FROM scene_triggers_legacy";
+constexpr const char* MIGRATE_DROP_SQL    = "DROP TABLE scene_triggers_legacy";
+constexpr const char* LEGACY_EXISTS_SQL   = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='scene_triggers'";
+constexpr const char* READ_USER_VERSION   = "PRAGMA user_version";
+constexpr const char* SET_USER_VERSION_V1 = "PRAGMA user_version = 1";
+
+// 1-based bind positions for the 6-column trigger upsert (named so the 5th /
+// 6th stay out of the magic-number checker; positions 1-4 are small enough
+// to be left as literals in the other statements).
 constexpr int BIND_TRIGGER_HOME     = 1;
 constexpr int BIND_TRIGGER_SOURCE   = 2;
-constexpr int BIND_TRIGGER_SCENE_NO = 3;
-constexpr int BIND_TRIGGER_KEY      = 4;
-constexpr int BIND_TRIGGER_SCENE_ID = 5;
+constexpr int BIND_TRIGGER_NODE     = 3;
+constexpr int BIND_TRIGGER_SCENE_NO = 4;
+constexpr int BIND_TRIGGER_KEY      = 5;
+constexpr int BIND_TRIGGER_SCENE_ID = 6;
 
 // Versioned, length-prefixed serialization of a scene's action list (same
 // idiom as PolicyRegister's policy blob — the leading version byte makes a
@@ -198,6 +223,66 @@ class Stmt
     sqlite3* database_  = nullptr;
     const char* label_  = nullptr;
 };
+
+/// Run one bare SQL statement, logging on failure. Returns success.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): SQL and label are clearly distinct at call sites
+auto execSql(sqlite3* database, const char* sql, const char* label) -> bool
+{
+    char* err = nullptr;
+    if (sqlite3_exec(database, sql, nullptr, nullptr, &err) != SQLITE_OK)
+    {
+        Logger::error(std::string("[SceneStore] ") + label + " failed: " + (err != nullptr ? err : "?"));
+        sqlite3_free(err);
+        return false;
+    }
+    return true;
+}
+
+/// Create the schema and migrate a pre-#124 (v0) trigger table to v1 (adds
+/// the `source` discriminator). Idempotent: a fresh DB gets the v1 tables
+/// directly; an already-migrated DB (user_version == 1) is left untouched.
+auto runSchema(sqlite3* database) -> bool
+{
+    if (!execSql(database, SCHEMA_SCENES_SQL, "CREATE scenes"))
+    {
+        return false;
+    }
+    int userVersion = 0;
+    {
+        Stmt stmt(database, READ_USER_VERSION, "read user_version");
+        if (stmt.valid() && stmt.step() == SQLITE_ROW)
+        {
+            userVersion = sqlite3_column_int(stmt.raw(), 0);
+        }
+    }
+    if (userVersion >= SCHEMA_VERSION)
+    {
+        // Already migrated — the v1 scene_triggers table is present.
+        return true;
+    }
+    // Does a legacy (v0) scene_triggers table exist to migrate from?
+    bool legacy = false;
+    {
+        Stmt stmt(database, LEGACY_EXISTS_SQL, "check legacy triggers");
+        legacy = stmt.valid() && stmt.step() == SQLITE_ROW;
+    }
+    if (legacy)
+    {
+        if (!execSql(database, MIGRATE_RENAME_SQL, "rename legacy triggers") ||
+            !execSql(database, SCHEMA_TRIGGERS_SQL, "CREATE scene_triggers") ||
+            !execSql(database, MIGRATE_COPY_SQL, "copy legacy triggers") ||
+            !execSql(database, MIGRATE_DROP_SQL, "drop legacy triggers"))
+        {
+            return false;
+        }
+        Logger::info("[SceneStore] migrated scene_triggers to v1 (added source discriminator)");
+    }
+    else if (!execSql(database, SCHEMA_TRIGGERS_SQL, "CREATE scene_triggers"))
+    {
+        return false;
+    }
+    return execSql(database, SET_USER_VERSION_V1, "set user_version");
+}
 }  // namespace
 
 // NOLINTBEGIN(misc-non-private-member-variables-in-classes): pimpl, public members read like a struct
@@ -241,11 +326,8 @@ SceneStore::Store::Store(const std::filesystem::path& dbPath)
         state_->db = nullptr;
         return;
     }
-    char* err = nullptr;
-    if (sqlite3_exec(state_->db, SCHEMA_SQL, nullptr, nullptr, &err) != SQLITE_OK)
+    if (!runSchema(state_->db))
     {
-        Logger::error(std::string("[SceneStore] CREATE TABLE failed: ") + (err != nullptr ? err : "?"));
-        sqlite3_free(err);
         sqlite3_close(state_->db);
         state_->db = nullptr;
         return;
@@ -353,7 +435,8 @@ auto SceneStore::Store::listScenes() const -> std::vector<std::string>
     return out;
 }
 
-auto SceneStore::Store::bindTrigger(std::uint8_t sourceNodeId,
+auto SceneStore::Store::bindTrigger(std::uint8_t source,
+                                    std::uint8_t sourceNodeId,
                                     std::uint8_t sceneNumber,
                                     std::uint8_t keyAttribute,
                                     const std::string& sceneId) -> void
@@ -370,7 +453,8 @@ auto SceneStore::Store::bindTrigger(std::uint8_t sourceNodeId,
     if (stmt.valid())
     {
         stmt.bindText(BIND_TRIGGER_HOME, home)
-            .bindInt(BIND_TRIGGER_SOURCE, sourceNodeId)
+            .bindInt(BIND_TRIGGER_SOURCE, source)
+            .bindInt(BIND_TRIGGER_NODE, sourceNodeId)
             .bindInt(BIND_TRIGGER_SCENE_NO, sceneNumber)
             .bindInt(BIND_TRIGGER_KEY, keyAttribute)
             .bindText(BIND_TRIGGER_SCENE_ID, sceneId)
@@ -378,7 +462,8 @@ auto SceneStore::Store::bindTrigger(std::uint8_t sourceNodeId,
     }
 }
 
-auto SceneStore::Store::unbindTrigger(std::uint8_t sourceNodeId,
+auto SceneStore::Store::unbindTrigger(std::uint8_t source,
+                                      std::uint8_t sourceNodeId,
                                       std::uint8_t sceneNumber,
                                       std::uint8_t keyAttribute) -> void
 {
@@ -392,11 +477,17 @@ auto SceneStore::Store::unbindTrigger(std::uint8_t sourceNodeId,
     Stmt stmt(state_->db, DELETE_TRIGGER_SQL, "DELETE trigger");
     if (stmt.valid())
     {
-        stmt.bindText(1, home).bindInt(2, sourceNodeId).bindInt(3, sceneNumber).bindInt(4, keyAttribute).execDone();
+        stmt.bindText(BIND_TRIGGER_HOME, home)
+            .bindInt(BIND_TRIGGER_SOURCE, source)
+            .bindInt(BIND_TRIGGER_NODE, sourceNodeId)
+            .bindInt(BIND_TRIGGER_SCENE_NO, sceneNumber)
+            .bindInt(BIND_TRIGGER_KEY, keyAttribute)
+            .execDone();
     }
 }
 
-auto SceneStore::Store::resolveTrigger(std::uint8_t sourceNodeId,
+auto SceneStore::Store::resolveTrigger(std::uint8_t source,
+                                       std::uint8_t sourceNodeId,
                                        std::uint8_t sceneNumber,
                                        std::uint8_t keyAttribute) const -> std::optional<std::string>
 {
@@ -412,7 +503,11 @@ auto SceneStore::Store::resolveTrigger(std::uint8_t sourceNodeId,
     {
         return std::nullopt;
     }
-    stmt.bindText(1, home).bindInt(2, sourceNodeId).bindInt(3, sceneNumber).bindInt(4, keyAttribute);
+    stmt.bindText(BIND_TRIGGER_HOME, home)
+        .bindInt(BIND_TRIGGER_SOURCE, source)
+        .bindInt(BIND_TRIGGER_NODE, sourceNodeId)
+        .bindInt(BIND_TRIGGER_SCENE_NO, sceneNumber)
+        .bindInt(BIND_TRIGGER_KEY, keyAttribute);
     if (stmt.step() != SQLITE_ROW)
     {
         return std::nullopt;
@@ -444,10 +539,11 @@ auto SceneStore::Store::listTriggers() const -> std::vector<Trigger>
     while (stmt.step() == SQLITE_ROW)
     {
         Trigger trigger;
-        trigger.sourceNodeId = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 0));
-        trigger.sceneNumber  = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 1));
-        trigger.keyAttribute = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 2));
-        const auto* text     = sqlite3_column_text(stmt.raw(), 3);
+        trigger.source       = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 0));
+        trigger.sourceNodeId = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 1));
+        trigger.sceneNumber  = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 2));
+        trigger.keyAttribute = static_cast<std::uint8_t>(sqlite3_column_int(stmt.raw(), 3));
+        const auto* text     = sqlite3_column_text(stmt.raw(), 4);
         if (text != nullptr)
         {
             trigger.sceneId =

--- a/src/scene-store/SceneStore.hpp
+++ b/src/scene-store/SceneStore.hpp
@@ -25,6 +25,16 @@
 /// the D-Bus surface (#122) build on top.
 namespace SceneStore
 {
+/// Which Command Class a trigger fires from. Discriminates the trigger key
+/// so the same (node, selector) can't collide across sources (#124). The
+/// `sceneNumber`/`keyAttribute` fields are reinterpreted per source:
+///   SOURCE_CENTRAL_SCENE    — sceneNumber = scene, keyAttribute = key attr
+///   SOURCE_BASIC_SET        — sceneNumber = Basic value, keyAttribute = 0
+///   SOURCE_SCENE_ACTIVATION — sceneNumber = scene id,    keyAttribute = 0
+constexpr std::uint8_t SOURCE_CENTRAL_SCENE    = 0;
+constexpr std::uint8_t SOURCE_BASIC_SET        = 1;
+constexpr std::uint8_t SOURCE_SCENE_ACTIVATION = 2;
+
 /// One step of a scene: send `ccPayload` (a raw Command Class frame, the
 /// same bytes a `SendData` carries) to `targetNodeId`.
 struct Action
@@ -33,9 +43,12 @@ struct Action
     std::vector<std::uint8_t> ccPayload;
 };
 
-/// A press-to-scene binding.
+/// A press-to-scene binding. `source` selects which CC the press arrives on
+/// (see SOURCE_* above); `sceneNumber`/`keyAttribute` are the per-source
+/// selector fields.
 struct Trigger
 {
+    std::uint8_t source       = SOURCE_CENTRAL_SCENE;
     std::uint8_t sourceNodeId = 0;
     std::uint8_t sceneNumber  = 0;
     std::uint8_t keyAttribute = 0;
@@ -75,21 +88,27 @@ class Store
     [[nodiscard]] auto listScenes() const -> std::vector<std::string>;
 
     // ---- Triggers ----
-    /// Bind (or rebind) a press to a scene id.
+    /// Bind (or rebind) a press to a scene id. `source` is one of SOURCE_*;
+    /// `sceneNumber`/`keyAttribute` are the per-source selector fields.
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire fields, named at call sites
-    auto bindTrigger(std::uint8_t sourceNodeId,
+    auto bindTrigger(std::uint8_t source,
+                     std::uint8_t sourceNodeId,
                      std::uint8_t sceneNumber,
                      std::uint8_t keyAttribute,
                      const std::string& sceneId) -> void;
     /// Remove a press binding (no-op if absent).
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire fields, named at call sites
-    auto unbindTrigger(std::uint8_t sourceNodeId, std::uint8_t sceneNumber, std::uint8_t keyAttribute) -> void;
+    auto unbindTrigger(std::uint8_t source,
+                       std::uint8_t sourceNodeId,
+                       std::uint8_t sceneNumber,
+                       std::uint8_t keyAttribute) -> void;
     /// Resolve a press to its scene id, or nullopt if no binding.
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire fields, named at call sites
-    [[nodiscard]] auto resolveTrigger(std::uint8_t sourceNodeId,
+    [[nodiscard]] auto resolveTrigger(std::uint8_t source,
+                                      std::uint8_t sourceNodeId,
                                       std::uint8_t sceneNumber,
                                       std::uint8_t keyAttribute) const -> std::optional<std::string>;
-    /// All triggers for the current home, ordered by (source, scene, key).
+    /// All triggers for the current home, ordered by (source, node, scene, key).
     [[nodiscard]] auto listTriggers() const -> std::vector<Trigger>;
 
   private:

--- a/src/zwave-protocol/application/Basic.cpp
+++ b/src/zwave-protocol/application/Basic.cpp
@@ -13,6 +13,8 @@ namespace
 constexpr std::size_t REPORT_V1_BYTES = 3;
 // v2 adds targetValue + duration after currentValue.
 constexpr std::size_t REPORT_V2_BYTES = 5;
+// CC byte + cmd byte + value.
+constexpr std::size_t SET_BYTES = 3;
 }  // namespace
 
 auto Basic::decodeReport(std::span<const uint8_t> payload) -> std::optional<Report>
@@ -37,5 +39,16 @@ auto Basic::decodeReport(std::span<const uint8_t> payload) -> std::optional<Repo
         // information is available.
         out.targetValue = out.currentValue;
     }
+    return out;
+}
+
+auto Basic::decodeSet(std::span<const uint8_t> payload) -> std::optional<Set>
+{
+    if (payload.size() < SET_BYTES || payload[0] != COMMAND_CLASS || payload[1] != BASIC_SET)
+    {
+        return std::nullopt;
+    }
+    Set out;
+    out.value = payload[2];
     return out;
 }

--- a/src/zwave-protocol/application/Basic.hpp
+++ b/src/zwave-protocol/application/Basic.hpp
@@ -47,6 +47,19 @@ struct Report
 /// Accepts both v1 (3 bytes) and v2+ (5 bytes) wire forms. Returns
 /// std::nullopt if the bytes are not a Basic Report.
 [[nodiscard]] auto decodeReport(std::span<const uint8_t> payload) -> std::optional<Report>;
+
+/// Decoded Basic Set payload — what a node sends *to us* when it drives
+/// its association target with a Basic Set (PIR sensors, simple wall
+/// switches). Single value byte, same semantics as a Report's value.
+struct Set
+{
+    uint8_t value = VALUE_OFF;
+};
+
+/// Decode a Basic Set payload (the bytes inside an
+/// APPLICATION_COMMAND_HANDLER frame, starting with COMMAND_CLASS).
+/// Returns std::nullopt if the bytes are not a Basic Set.
+[[nodiscard]] auto decodeSet(std::span<const uint8_t> payload) -> std::optional<Set>;
 }  // namespace Basic
 
 #endif  // ZWAVED_BASIC_HPP

--- a/src/zwave-protocol/application/CMakeLists.txt
+++ b/src/zwave-protocol/application/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(zwaved PRIVATE
     Meter.cpp
     ColorSwitch.cpp
     CentralScene.cpp
+    SceneActivation.cpp
     ThermostatMode.cpp
     ThermostatSetpoint.cpp
     ThermostatOperatingState.cpp

--- a/src/zwave-protocol/application/SceneActivation.cpp
+++ b/src/zwave-protocol/application/SceneActivation.cpp
@@ -1,0 +1,30 @@
+#include "SceneActivation.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+namespace
+{
+// CC byte + cmd byte + sceneId. The dimming-duration byte is optional on
+// the wire (v1 omits it); default it to 0 (instant) when absent.
+constexpr std::size_t SET_MIN_BYTES   = 3;
+constexpr std::size_t OFFSET_SCENE_ID = 2;
+constexpr std::size_t OFFSET_DURATION = 3;
+}  // namespace
+
+auto SceneActivation::decodeSet(std::span<const std::uint8_t> payload) -> std::optional<Set>
+{
+    if (payload.size() < SET_MIN_BYTES || payload[0] != COMMAND_CLASS || payload[1] != SCENE_ACTIVATION_SET)
+    {
+        return std::nullopt;
+    }
+    Set out;
+    out.sceneId = payload[OFFSET_SCENE_ID];
+    if (payload.size() > OFFSET_DURATION)
+    {
+        out.dimmingDuration = payload[OFFSET_DURATION];
+    }
+    return out;
+}

--- a/src/zwave-protocol/application/SceneActivation.hpp
+++ b/src/zwave-protocol/application/SceneActivation.hpp
@@ -1,0 +1,35 @@
+#ifndef ZWAVED_SCENE_ACTIVATION_HPP
+#define ZWAVED_SCENE_ACTIVATION_HPP
+
+// IWYU pragma: begin_exports
+#include "SceneActivation.gen.hpp"
+// IWYU pragma: end_exports
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+/// Z-Wave Scene Activation Command Class (0x2B). Push-only: scene
+/// controllers announce "scene N is now active" via SCENE_ACTIVATION_SET.
+/// The daemon never sends Scene Activation frames; it only decodes the
+/// inbound SET into a typed signal the SceneOrchestrator (#124) keys
+/// triggers on. Constants come from SceneActivation.gen.hpp.
+namespace SceneActivation
+{
+/// Decoded Scene Activation Set payload. `sceneId` is the activated scene
+/// number (1..255; 0 means "no scene active"). `dimmingDuration` is the
+/// requested transition time: 0x00 instant, 0x01..0x7F seconds,
+/// 0x80..0xFE minutes, 0xFF factory default.
+struct Set
+{
+    std::uint8_t sceneId         = 0;
+    std::uint8_t dimmingDuration = 0;
+};
+
+/// Decode a Scene Activation Set payload (the bytes inside an
+/// APPLICATION_COMMAND_HANDLER frame, starting with COMMAND_CLASS).
+/// Returns std::nullopt if the bytes are not a well-formed Set.
+[[nodiscard]] auto decodeSet(std::span<const std::uint8_t> payload) -> std::optional<Set>;
+}  // namespace SceneActivation
+
+#endif  // ZWAVED_SCENE_ACTIVATION_HPP

--- a/tests/Basic_test.cpp
+++ b/tests/Basic_test.cpp
@@ -98,3 +98,29 @@ TEST(Basic, DecodeReportRejectsWrongCommand)
     const std::array<std::uint8_t, 3> bytes{CC_BASIC, CMD_SET, VALUE_ON};
     EXPECT_FALSE(Basic::decodeReport(std::span<const std::uint8_t>(bytes)).has_value());
 }
+
+TEST(Basic, DecodeSetOnAndOff)
+{
+    const std::array<std::uint8_t, 3> onBytes{CC_BASIC, CMD_SET, VALUE_ON};
+    const auto on = Basic::decodeSet(std::span<const std::uint8_t>(onBytes));
+    ASSERT_TRUE(on.has_value());
+    EXPECT_EQ(on->value, VALUE_ON);
+
+    const std::array<std::uint8_t, 3> offBytes{CC_BASIC, CMD_SET, VALUE_OFF};
+    const auto off = Basic::decodeSet(std::span<const std::uint8_t>(offBytes));
+    ASSERT_TRUE(off.has_value());
+    EXPECT_EQ(off->value, VALUE_OFF);
+}
+
+TEST(Basic, DecodeSetRejectsReportAndTooShort)
+{
+    // A Report is not a Set.
+    const std::array<std::uint8_t, 3> report{CC_BASIC, CMD_REPORT, VALUE_ON};
+    EXPECT_FALSE(Basic::decodeSet(std::span<const std::uint8_t>(report)).has_value());
+    // Too short (missing value byte).
+    const std::array<std::uint8_t, 2> tooShort{CC_BASIC, CMD_SET};
+    EXPECT_FALSE(Basic::decodeSet(std::span<const std::uint8_t>(tooShort)).has_value());
+    // Wrong command class.
+    const std::array<std::uint8_t, 3> wrongCc{0x25, CMD_SET, VALUE_ON};
+    EXPECT_FALSE(Basic::decodeSet(std::span<const std::uint8_t>(wrongCc)).has_value());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -316,6 +316,20 @@ target_link_libraries(CentralScene_test PRIVATE GTest::gtest GTest::gtest_main)
 zwaved_test_target(CentralScene_test)
 gtest_discover_tests(CentralScene_test)
 
+# ---- SceneActivation ------------------------------------------------
+# No .gen.cpp (push-only; decode-only, no encoders).
+add_executable(SceneActivation_test
+    SceneActivation_test.cpp
+    "${SRC_DIR}/application/SceneActivation.cpp"
+)
+target_include_directories(SceneActivation_test PRIVATE
+    "${SRC_DIR}/application"
+    "${GENERATED_APPLICATION_DIR}"
+)
+target_link_libraries(SceneActivation_test PRIVATE GTest::gtest GTest::gtest_main)
+zwaved_test_target(SceneActivation_test)
+gtest_discover_tests(SceneActivation_test)
+
 # ---- DoorLock -------------------------------------------------------
 add_executable(DoorLock_test
     DoorLock_test.cpp

--- a/tests/SceneActivation_test.cpp
+++ b/tests/SceneActivation_test.cpp
@@ -1,0 +1,46 @@
+#include "SceneActivation.hpp"
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr std::uint8_t CC_SCENE_ACTIVATION = 0x2B;
+constexpr std::uint8_t CMD_SET             = 0x01;
+}  // namespace
+
+TEST(SceneActivation, DecodeSetWithDuration)
+{
+    // scene 3, dimming duration 5 seconds.
+    const std::array<std::uint8_t, 4> bytes{CC_SCENE_ACTIVATION, CMD_SET, 0x03, 0x05};
+    const auto decoded = SceneActivation::decodeSet(std::span<const std::uint8_t>(bytes));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->sceneId, 3);
+    EXPECT_EQ(decoded->dimmingDuration, 5);
+}
+
+TEST(SceneActivation, DecodeSetWithoutDurationDefaultsZero)
+{
+    // v1 wire form omits the duration byte.
+    const std::array<std::uint8_t, 3> bytes{CC_SCENE_ACTIVATION, CMD_SET, 0x07};
+    const auto decoded = SceneActivation::decodeSet(std::span<const std::uint8_t>(bytes));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->sceneId, 7);
+    EXPECT_EQ(decoded->dimmingDuration, 0);
+}
+
+TEST(SceneActivation, RejectsMalformed)
+{
+    // Too short (missing scene id).
+    const std::array<std::uint8_t, 2> tooShort{CC_SCENE_ACTIVATION, CMD_SET};
+    EXPECT_FALSE(SceneActivation::decodeSet(std::span<const std::uint8_t>(tooShort)).has_value());
+    // Wrong command class.
+    const std::array<std::uint8_t, 3> wrongCc{0x25, CMD_SET, 0x03};
+    EXPECT_FALSE(SceneActivation::decodeSet(std::span<const std::uint8_t>(wrongCc)).has_value());
+    // Wrong command byte.
+    const std::array<std::uint8_t, 3> wrongCmd{CC_SCENE_ACTIVATION, 0x02, 0x03};
+    EXPECT_FALSE(SceneActivation::decodeSet(std::span<const std::uint8_t>(wrongCmd)).has_value());
+}

--- a/tests/SceneOrchestrator_test.cpp
+++ b/tests/SceneOrchestrator_test.cpp
@@ -86,7 +86,7 @@ TEST_F(SceneOrchestratorTest, RunsBoundSceneActionsInOrder)
     SceneStore::instance().setScene("tv",
                                     {SceneStore::Action{.targetNodeId = 5, .ccPayload = payload({0x25, 0x01, 0xFF})},
                                      SceneStore::Action{.targetNodeId = 6, .ccPayload = payload({0x25, 0x01, 0x00})}});
-    SceneStore::instance().bindTrigger(7, 1, 0, "tv");
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_CENTRAL_SCENE, 7, 1, 0, "tv");
 
     Recorder rec;
     MessageBus::publish(MessageBus::CentralSceneNotification{
@@ -105,8 +105,8 @@ TEST_F(SceneOrchestratorTest, ContextDependentBySourceNode)
                                     {SceneStore::Action{.targetNodeId = 5, .ccPayload = payload({0x25, 0x01, 0xFF})}});
     SceneStore::instance().setScene("hall",
                                     {SceneStore::Action{.targetNodeId = 8, .ccPayload = payload({0x25, 0x01, 0x00})}});
-    SceneStore::instance().bindTrigger(20, 1, 0, "living");
-    SceneStore::instance().bindTrigger(21, 1, 0, "hall");
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_CENTRAL_SCENE, 20, 1, 0, "living");
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_CENTRAL_SCENE, 21, 1, 0, "hall");
 
     Recorder rec;
     MessageBus::publish(MessageBus::CentralSceneNotification{
@@ -127,10 +127,59 @@ TEST_F(SceneOrchestratorTest, UnboundPressIsInert)
 
 TEST_F(SceneOrchestratorTest, TriggerToMissingSceneActivatesWithZeroActions)
 {
-    SceneStore::instance().bindTrigger(30, 2, 3, "deleted-scene");  // never created
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_CENTRAL_SCENE, 30, 2, 3, "deleted-scene");  // never created
     Recorder rec;
     MessageBus::publish(MessageBus::CentralSceneNotification{
         .sourceNodeId = 30, .sequenceNumber = 1, .keyAttribute = 3, .sceneNumber = 2, .slowRefresh = false});
     ASSERT_EQ(rec.log.size(), 1U);
     EXPECT_EQ(rec.log[0], "scene:30:deleted-scene:0");  // activated, but no actions dispatched
+}
+
+TEST_F(SceneOrchestratorTest, RunsSceneFromBasicSet)
+{
+    // A Basic Set value 0xFF from node 40 runs scene "lights-on".
+    SceneStore::instance().setScene("lights-on",
+                                    {SceneStore::Action{.targetNodeId = 9, .ccPayload = payload({0x25, 0x01, 0xFF})}});
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_BASIC_SET, 40, 0xFF, 0, "lights-on");
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::BasicSetReceived{.sourceNodeId = 40, .value = 0xFF});
+
+    ASSERT_EQ(rec.log.size(), 2U);
+    EXPECT_EQ(rec.log[0], "send:9:37,1,255,");
+    EXPECT_EQ(rec.log[1], "scene:40:lights-on:1");  // SceneActivated carries value as sceneNumber
+}
+
+TEST_F(SceneOrchestratorTest, BasicSetDistinctFromCentralScene)
+{
+    // Same (node, selector) on Basic Set vs Central Scene run different scenes.
+    SceneStore::instance().setScene("basic-scene",
+                                    {SceneStore::Action{.targetNodeId = 9, .ccPayload = payload({0x25, 0x01, 0x00})}});
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_BASIC_SET, 41, 1, 0, "basic-scene");
+
+    Recorder rec;
+    // A Central Scene press with the same (node, selector, key) is unbound.
+    MessageBus::publish(MessageBus::CentralSceneNotification{
+        .sourceNodeId = 41, .sequenceNumber = 1, .keyAttribute = 0, .sceneNumber = 1, .slowRefresh = false});
+    EXPECT_TRUE(rec.log.empty());  // Central Scene side has no binding
+
+    MessageBus::publish(MessageBus::BasicSetReceived{.sourceNodeId = 41, .value = 1});
+    ASSERT_EQ(rec.log.size(), 2U);
+    EXPECT_EQ(rec.log[0], "send:9:37,1,0,");
+    EXPECT_EQ(rec.log[1], "scene:41:basic-scene:1");
+}
+
+TEST_F(SceneOrchestratorTest, RunsSceneFromSceneActivation)
+{
+    // A Scene Activation Set for scene 3 from node 50 runs scene "movie".
+    SceneStore::instance().setScene("movie",
+                                    {SceneStore::Action{.targetNodeId = 9, .ccPayload = payload({0x25, 0x01, 0xFF})}});
+    SceneStore::instance().bindTrigger(SceneStore::SOURCE_SCENE_ACTIVATION, 50, 3, 0, "movie");
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::SceneActivationSet{.sourceNodeId = 50, .sceneId = 3, .dimmingDuration = 0});
+
+    ASSERT_EQ(rec.log.size(), 2U);
+    EXPECT_EQ(rec.log[0], "send:9:37,1,255,");
+    EXPECT_EQ(rec.log[1], "scene:50:movie:1");  // SceneActivated carries sceneId as sceneNumber
 }

--- a/tests/SceneStore_test.cpp
+++ b/tests/SceneStore_test.cpp
@@ -98,60 +98,89 @@ TEST_F(SceneStoreTest, ListAndDeleteScenes)
 
 TEST_F(SceneStoreTest, TriggerResolveHitAndMiss)
 {
+    using SceneStore::SOURCE_CENTRAL_SCENE;
     SceneStore::Store store(dbPath_);
     store.setHomeId(kHomeId);
-    store.bindTrigger(7, 1, 0, "TV mode");    // living room, scene 1, press 1x
-    store.bindTrigger(12, 1, 0, "Good bye");  // hallway, same scene number
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0, "TV mode");    // living room, scene 1, press 1x
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 12, 1, 0, "Good bye");  // hallway, same scene number
 
-    EXPECT_EQ(store.resolveTrigger(7, 1, 0), std::optional<std::string>("TV mode"));
-    EXPECT_EQ(store.resolveTrigger(12, 1, 0), std::optional<std::string>("Good bye"));
-    EXPECT_FALSE(store.resolveTrigger(7, 2, 0).has_value());   // different scene number
-    EXPECT_FALSE(store.resolveTrigger(99, 1, 0).has_value());  // unknown source
+    EXPECT_EQ(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0), std::optional<std::string>("TV mode"));
+    EXPECT_EQ(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 12, 1, 0), std::optional<std::string>("Good bye"));
+    EXPECT_FALSE(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 2, 0).has_value());   // different scene number
+    EXPECT_FALSE(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 99, 1, 0).has_value());  // unknown source
 }
 
 TEST_F(SceneStoreTest, TriggerRebindAndUnbind)
 {
+    using SceneStore::SOURCE_CENTRAL_SCENE;
     SceneStore::Store store(dbPath_);
     store.setHomeId(kHomeId);
-    store.bindTrigger(7, 1, 0, "scene-a");
-    store.bindTrigger(7, 1, 0, "scene-b");  // rebind same key
-    EXPECT_EQ(store.resolveTrigger(7, 1, 0), std::optional<std::string>("scene-b"));
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0, "scene-a");
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0, "scene-b");  // rebind same key
+    EXPECT_EQ(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0), std::optional<std::string>("scene-b"));
     EXPECT_EQ(store.listTriggers().size(), 1U);  // rebind, not a second row
-    store.unbindTrigger(7, 1, 0);
-    EXPECT_FALSE(store.resolveTrigger(7, 1, 0).has_value());
+    store.unbindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0);
+    EXPECT_FALSE(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0).has_value());
     EXPECT_TRUE(store.listTriggers().empty());
+}
+
+TEST_F(SceneStoreTest, TriggerSourceDiscriminator)
+{
+    // Same (node, selector, key) on three different sources are distinct
+    // rows that resolve independently — no collision (#124).
+    using SceneStore::SOURCE_BASIC_SET;
+    using SceneStore::SOURCE_CENTRAL_SCENE;
+    using SceneStore::SOURCE_SCENE_ACTIVATION;
+    SceneStore::Store store(dbPath_);
+    store.setHomeId(kHomeId);
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 5, 1, 0, "central");
+    store.bindTrigger(SOURCE_BASIC_SET, 5, 1, 0, "basic");
+    store.bindTrigger(SOURCE_SCENE_ACTIVATION, 5, 1, 0, "activation");
+
+    EXPECT_EQ(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 5, 1, 0), std::optional<std::string>("central"));
+    EXPECT_EQ(store.resolveTrigger(SOURCE_BASIC_SET, 5, 1, 0), std::optional<std::string>("basic"));
+    EXPECT_EQ(store.resolveTrigger(SOURCE_SCENE_ACTIVATION, 5, 1, 0), std::optional<std::string>("activation"));
+    EXPECT_EQ(store.listTriggers().size(), 3U);  // three distinct rows
+
+    // Unbinding one source leaves the others intact.
+    store.unbindTrigger(SOURCE_BASIC_SET, 5, 1, 0);
+    EXPECT_FALSE(store.resolveTrigger(SOURCE_BASIC_SET, 5, 1, 0).has_value());
+    EXPECT_TRUE(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 5, 1, 0).has_value());
+    EXPECT_TRUE(store.resolveTrigger(SOURCE_SCENE_ACTIVATION, 5, 1, 0).has_value());
 }
 
 TEST_F(SceneStoreTest, PersistsAcrossRestart)
 {
+    using SceneStore::SOURCE_CENTRAL_SCENE;
     {
         SceneStore::Store store(dbPath_);
         store.setHomeId(kHomeId);
         store.setScene("TV mode", {action(5, {0x25, 0x01, 0xFF})});
-        store.bindTrigger(7, 1, 0, "TV mode");
+        store.bindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0, "TV mode");
     }  // first "daemon" stops
 
     SceneStore::Store reopened(dbPath_);  // second "daemon" starts on the same file
     reopened.setHomeId(kHomeId);
     EXPECT_TRUE(reopened.getScene("TV mode").has_value());
-    EXPECT_EQ(reopened.resolveTrigger(7, 1, 0), std::optional<std::string>("TV mode"));
+    EXPECT_EQ(reopened.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0), std::optional<std::string>("TV mode"));
 }
 
 TEST_F(SceneStoreTest, HomeScoping)
 {
+    using SceneStore::SOURCE_CENTRAL_SCENE;
     SceneStore::Store store(dbPath_);
     store.setHomeId(kHomeId);
     store.setScene("TV mode", {action(5, {0x25, 0x01, 0xFF})});
-    store.bindTrigger(7, 1, 0, "TV mode");
+    store.bindTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0, "TV mode");
 
     store.setHomeId(kOtherHome);  // different network
     EXPECT_FALSE(store.getScene("TV mode").has_value());
-    EXPECT_FALSE(store.resolveTrigger(7, 1, 0).has_value());
+    EXPECT_FALSE(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0).has_value());
     EXPECT_TRUE(store.listScenes().empty());
 
     store.setHomeId(kHomeId);  // back to the original network
     EXPECT_TRUE(store.getScene("TV mode").has_value());
-    EXPECT_EQ(store.resolveTrigger(7, 1, 0), std::optional<std::string>("TV mode"));
+    EXPECT_EQ(store.resolveTrigger(SOURCE_CENTRAL_SCENE, 7, 1, 0), std::optional<std::string>("TV mode"));
 }
 
 TEST_F(SceneStoreTest, NoHomeBoundIsGraceful)
@@ -160,5 +189,5 @@ TEST_F(SceneStoreTest, NoHomeBoundIsGraceful)
     store.setScene("x", {action(1, {0x01})});
     EXPECT_FALSE(store.getScene("x").has_value());
     EXPECT_TRUE(store.listScenes().empty());
-    EXPECT_FALSE(store.resolveTrigger(1, 1, 0).has_value());
+    EXPECT_FALSE(store.resolveTrigger(SceneStore::SOURCE_CENTRAL_SCENE, 1, 1, 0).has_value());
 }

--- a/utils/zwave-terminal/handlers.cpp
+++ b/utils/zwave-terminal/handlers.cpp
@@ -13,6 +13,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdbus-c++/Error.h>
@@ -1100,7 +1101,50 @@ auto handleListDevicePolicies(sdbus::IProxy& proxy) -> void
 namespace
 {
 using SceneActionEntry  = sdbus::Struct<std::uint8_t, std::vector<std::uint8_t>>;
-using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
+using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t, std::uint8_t, std::string>;
+
+// Trigger-source discriminator, mirroring SceneStore SOURCE_* (#124).
+constexpr std::uint8_t SCENE_SOURCE_CENTRAL    = 0;
+constexpr std::uint8_t SCENE_SOURCE_BASIC      = 1;
+constexpr std::uint8_t SCENE_SOURCE_ACTIVATION = 2;
+
+// Human label for a trigger source byte.
+auto sceneSourceName(std::uint8_t source) -> const char*
+{
+    switch (source)
+    {
+    case SCENE_SOURCE_CENTRAL:
+        return "central-scene";
+    case SCENE_SOURCE_BASIC:
+        return "basic-set";
+    case SCENE_SOURCE_ACTIVATION:
+        return "scene-activation";
+    default:
+        return "?";
+    }
+}
+
+// Prompt for a trigger source kind. Maps the chosen letter to a SOURCE_*
+// byte; nullopt on cancel.
+auto promptSceneSource() -> std::optional<std::uint8_t>
+{
+    auto chosen = promptChar("Source: [c]entral scene  [b]asic set  [a]ctivation:", "cba");
+    if (!chosen.has_value())
+    {
+        return std::nullopt;
+    }
+    switch (*chosen)
+    {
+    case 'c':
+        return SCENE_SOURCE_CENTRAL;
+    case 'b':
+        return SCENE_SOURCE_BASIC;
+    case 'a':
+        return SCENE_SOURCE_ACTIVATION;
+    default:
+        return std::nullopt;
+    }
+}
 
 // Render a raw CC payload as space-separated hex for the activity log.
 auto formatPayloadHex(const std::vector<std::uint8_t>& payload) -> std::string
@@ -1178,19 +1222,25 @@ auto handleListSceneTriggers(sdbus::IProxy& proxy) -> void
     logLine("Scene triggers (" + std::to_string(triggers.size()) + "):");
     for (const auto& trigger : triggers)
     {
-        const std::uint8_t keyAttribute = std::get<2>(trigger);
+        const std::uint8_t source       = std::get<0>(trigger);
+        const std::uint8_t keyAttribute = std::get<3>(trigger);
         std::ostringstream stream;
-        stream << "  node " << static_cast<unsigned>(std::get<0>(trigger)) << " scene "
-               << static_cast<unsigned>(std::get<1>(trigger)) << " ";
-        if (const char* name = centralSceneKeyName(keyAttribute); name != nullptr)
+        stream << "  [" << sceneSourceName(source) << "] node " << static_cast<unsigned>(std::get<1>(trigger))
+               << " sel " << static_cast<unsigned>(std::get<2>(trigger));
+        // The key attribute is only meaningful for Central Scene triggers.
+        if (source == SCENE_SOURCE_CENTRAL)
         {
-            stream << name;
+            stream << " ";
+            if (const char* name = centralSceneKeyName(keyAttribute); name != nullptr)
+            {
+                stream << name;
+            }
+            else
+            {
+                stream << "key=" << static_cast<unsigned>(keyAttribute);
+            }
         }
-        else
-        {
-            stream << "key=" << static_cast<unsigned>(keyAttribute);
-        }
-        stream << " -> \"" << std::get<3>(trigger) << "\"";
+        stream << " -> \"" << std::get<4>(trigger) << "\"";
         logLine(stream.str());
     }
 }
@@ -1255,14 +1305,62 @@ auto handleDeleteScene(sdbus::IProxy& proxy) -> void
     }
 }
 
+// Prompt the per-source selector + key attribute. The selector means scene
+// number / Basic value / activation scene id depending on `source`; only
+// Central Scene carries a meaningful key attribute (others are forced 0).
+auto promptTriggerSelector(std::uint8_t source) -> std::optional<std::pair<std::uint8_t, std::uint8_t>>
+{
+    const char* label = "Selector:";
+    switch (source)
+    {
+    case SCENE_SOURCE_CENTRAL:
+        label = "Scene number (1-255):";
+        break;
+    case SCENE_SOURCE_BASIC:
+        label = "Basic value (0=off, 255=on, 1-99=level):";
+        break;
+    case SCENE_SOURCE_ACTIVATION:
+        label = "Activation scene id (1-255):";
+        break;
+    default:
+        break;
+    }
+    auto selector = promptByte(label, 0, BYTE_MAX);
+    if (!selector.has_value())
+    {
+        return std::nullopt;
+    }
+    std::uint8_t keyAttribute = 0;
+    if (source == SCENE_SOURCE_CENTRAL)
+    {
+        auto key = promptByte("Key attribute (0=1x,1=release,2=hold,3=2x,4=3x):", 0, BYTE_MAX);
+        if (!key.has_value())
+        {
+            return std::nullopt;
+        }
+        keyAttribute = *key;
+    }
+    return std::make_pair(*selector, keyAttribute);
+}
+
 auto handleBindSceneTrigger(sdbus::IProxy& proxy) -> void
 {
-    auto sourceNode   = promptNodeId("Source node (controller pressing the button):");
-    auto sceneNumber  = promptByte("Scene number (1-255):", 1, BYTE_MAX);
-    auto keyAttribute = promptByte("Key attribute (0=1x,1=release,2=hold,3=2x,4=3x):", 0, BYTE_MAX);
-    if (!sourceNode.has_value() || !sceneNumber.has_value() || !keyAttribute.has_value())
+    auto source = promptSceneSource();
+    if (!source.has_value())
     {
-        logLine("BindSceneTrigger: cancelled or invalid input");
+        logLine("BindSceneTrigger: cancelled or invalid source");
+        return;
+    }
+    auto sourceNode = promptNodeId("Source node (controller that sends the command):");
+    if (!sourceNode.has_value())
+    {
+        logLine("BindSceneTrigger: cancelled or invalid node id");
+        return;
+    }
+    auto selector = promptTriggerSelector(*source);
+    if (!selector.has_value())
+    {
+        logLine("BindSceneTrigger: cancelled or invalid selector");
         return;
     }
     auto sceneId = promptLine("Scene id to bind to:");
@@ -1275,9 +1373,10 @@ auto handleBindSceneTrigger(sdbus::IProxy& proxy) -> void
     {
         proxy.callMethod("BindSceneTrigger")
             .onInterface(IFACE_NAME)
-            .withArguments(*sourceNode, *sceneNumber, *keyAttribute, *sceneId);
-        logLine("BindSceneTrigger node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
-                " scene=" + std::to_string(static_cast<unsigned>(*sceneNumber)) + " -> \"" + *sceneId + "\"");
+            .withArguments(*source, *sourceNode, selector->first, selector->second, *sceneId);
+        logLine(std::string{"BindSceneTrigger ["} + sceneSourceName(*source) +
+                "] node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
+                " sel=" + std::to_string(static_cast<unsigned>(selector->first)) + " -> \"" + *sceneId + "\"");
     }
     catch (const sdbus::Error& err)
     {
@@ -1287,21 +1386,32 @@ auto handleBindSceneTrigger(sdbus::IProxy& proxy) -> void
 
 auto handleUnbindSceneTrigger(sdbus::IProxy& proxy) -> void
 {
-    auto sourceNode   = promptNodeId("Source node:");
-    auto sceneNumber  = promptByte("Scene number (1-255):", 1, BYTE_MAX);
-    auto keyAttribute = promptByte("Key attribute (0-4):", 0, BYTE_MAX);
-    if (!sourceNode.has_value() || !sceneNumber.has_value() || !keyAttribute.has_value())
+    auto source = promptSceneSource();
+    if (!source.has_value())
     {
-        logLine("UnbindSceneTrigger: cancelled or invalid input");
+        logLine("UnbindSceneTrigger: cancelled or invalid source");
+        return;
+    }
+    auto sourceNode = promptNodeId("Source node:");
+    if (!sourceNode.has_value())
+    {
+        logLine("UnbindSceneTrigger: cancelled or invalid node id");
+        return;
+    }
+    auto selector = promptTriggerSelector(*source);
+    if (!selector.has_value())
+    {
+        logLine("UnbindSceneTrigger: cancelled or invalid selector");
         return;
     }
     try
     {
         proxy.callMethod("UnbindSceneTrigger")
             .onInterface(IFACE_NAME)
-            .withArguments(*sourceNode, *sceneNumber, *keyAttribute);
-        logLine("UnbindSceneTrigger node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
-                " scene=" + std::to_string(static_cast<unsigned>(*sceneNumber)));
+            .withArguments(*source, *sourceNode, selector->first, selector->second);
+        logLine(std::string{"UnbindSceneTrigger ["} + sceneSourceName(*source) +
+                "] node=" + std::to_string(static_cast<unsigned>(*sourceNode)) +
+                " sel=" + std::to_string(static_cast<unsigned>(selector->first)));
     }
     catch (const sdbus::Error& err)
     {

--- a/utils/zwave-terminal/signal_handlers.cpp
+++ b/utils/zwave-terminal/signal_handlers.cpp
@@ -187,6 +187,29 @@ auto registerSignalHandlers(sdbus::IProxy& proxy) -> void
                 logLine(stream.str());
             });
 
+    proxy.uponSignal("BasicSetReceived")
+        .onInterface(IFACE_NAME)
+        .call(
+            [](std::uint8_t sourceNodeId, std::uint8_t value) -> void
+            {
+                std::ostringstream stream;
+                stream << "BasicSetReceived node=" << static_cast<unsigned>(sourceNodeId)
+                       << " value=" << static_cast<unsigned>(value);
+                logLine(stream.str());
+            });
+
+    proxy.uponSignal("SceneActivationSet")
+        .onInterface(IFACE_NAME)
+        .call(
+            [](std::uint8_t sourceNodeId, std::uint8_t sceneId, std::uint8_t dimmingDuration) -> void
+            {
+                std::ostringstream stream;
+                stream << "SceneActivationSet node=" << static_cast<unsigned>(sourceNodeId)
+                       << " scene=" << static_cast<unsigned>(sceneId)
+                       << " duration=" << static_cast<unsigned>(dimmingDuration);
+                logLine(stream.str());
+            });
+
     proxy.uponSignal("DoorLockOperationReport")
         .onInterface(IFACE_NAME)
         .call(


### PR DESCRIPTION
Closes #124. Final child of the scene-controller epic #119 — the epic is now complete (#120 store, #121 orchestrator, #122 D-Bus, #123 terminal, #124 here, all merged/merging).

## What
The SceneOrchestrator initially only ran scenes from Central Scene (0x5B) presses. Many non-scene controllers instead drive their association target with a **Basic Set** (0x20) or announce a scene via **Scene Activation** (0x2B). This accepts both as additional trigger sources.

## Trigger model — a `source` discriminator
A trigger now carries a leading `source` byte (`0` Central Scene, `1` Basic Set, `2` Scene Activation) that is **part of the key**, so the same `(node, selector)` can be bound independently per source without colliding. `sceneNumber` is reinterpreted as a per-source selector (scene number / Basic value / activation scene id); `keyAttribute` stays meaningful only for Central Scene. SceneStore migrates a pre-#124 (v0) trigger table to v1 via `PRAGMA user_version`, stamping existing rows as Central Scene.

## Decode path
- `Basic::decodeSet` — decode an inbound Basic Set (CC 0x20 cmd 0x01).
- New **SceneActivation** CC (0x2B) codec — decode `SCENE_ACTIVATION_SET` (sceneId + dimming duration).
- cc-translator republishes both as new typed bus events `BasicSetReceived{node,value}` / `SceneActivationSet{node,sceneId,dimmingDuration}`, also exposed as D-Bus signals for observability.
- SceneOrchestrator subscribes to all three sources via one shared `runScene(source, node, selector, key)` helper.

## D-Bus + terminal (breaking, all unreleased)
- `BindSceneTrigger` / `UnbindSceneTrigger` gain a leading `source` byte (`y y y y s` / `y y y y`); `ListSceneTriggers` returns `a(yyyys)`.
- `zwave-terminal` `[e]` Scenes submenu prompts the source kind first, then the source-appropriate selector; the trigger list is tagged by source; the new signals render in the activity pane.

## Tests / verification
- New: `Basic::decodeSet` (2), SceneActivation codec (3), SceneStore source-discriminator no-collision (1), orchestrator Basic Set + Scene Activation runs (3).
- **301/301** tests pass on both gnu + llvm; clang-format + clang-tidy clean (pre-commit hook passed).

## Docs
- MANUAL §16d documents the source discriminator, new signatures, the trigger-source table, and `busctl` examples binding the same scene to a Central Scene press and a Basic Set.
- FUTURE.md marks epic #119 **complete**.

Note: the issue suggested bench-testing real wall controllers to decide which source to prioritise — I couldn't run hardware here, so I implemented **both** sources (they're symmetric). The decision gate is now moot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)