### PR TITLE
feat: NodeMetadata reverse lookup (nodes-by-tag) (#132)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -251,14 +251,20 @@ governs.
       Z-Stick Gen5 is a Static Controller (libtype 1). This only rules out
       E1 Tier 3; Tiers 1 (E2) and 2 are unaffected, so the foundation is not
       blocked.**
-- [ ] Confirm which CC real wall controllers emit to an association target (E2 /
-      Tier 1) — decides what the scene orchestrator keys on.
-- [ ] Decide whether `(sourceNode, command)` keying (Tier 1) is sufficient or
-      whether any target setup forces the Tier 2 endpoint spike.
-- [ ] Decide whether E3's control loop is in-scope or a separate epic.
-- [ ] Then split E2 / E3 (and, if pursued, E1 Tier 2/3) into per-PR child issues
-      (orchestrator, store, D-Bus, terminal — plus codecs for Tier 2/3) like the
-      thermostat quartet (#23).
+- [x] Confirm which CC real wall controllers emit to an association target (E2 /
+      Tier 1) — **resolved by implementing all three sources (#124): Central
+      Scene, Basic Set, and Scene Activation, behind a `source` discriminator,
+      so no single-CC bet was needed.**
+- [x] Decide whether `(sourceNode, command)` keying (Tier 1) is sufficient or
+      whether any target setup forces the Tier 2 endpoint spike — **Tier 1
+      keying shipped and sufficient for E2; Tier 2 remains an unscheduled E1
+      spike.**
+- [x] Decide whether E3's control loop is in-scope or a separate epic — **decided
+      2026-06-09: out of scope for epic #131 (aggregation/mirroring only); the
+      closed-loop control is deferred to its own future epic.**
+- [x] Then split E2 / E3 into per-PR child issues (orchestrator, store, D-Bus,
+      terminal) like the thermostat quartet (#23) — **E2 = #119 (#120–#124, all
+      merged); E3 = #131 (#132–#135). E1 Tier 2/3 not yet split.**
 
 ## Status / filed issues
 

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -267,11 +267,17 @@ governs.
   (D-Bus CRUD) ✅, **#123** (terminal UI) ✅, **#124** (extra trigger sources:
   Basic Set 0x20 + Scene Activation 0x2B, behind a `source` discriminator) ✅.
   Scenes run end-to-end from Central Scene, Basic Set, or Scene Activation
-  presses (see MANUAL §16d). E1/E3 remain exploratory here.
+  presses (see MANUAL §16d).
+- **E3 (thermostat management) is filed** as epic **#131**, scoped to
+  aggregation/mirroring (the closed-loop control deferred to its own epic) and
+  grouping via node metadata (#83) rather than a new store. Children: **#132**
+  (NodeMetadata reverse lookup / nodes-by-tag), **#133** (ThermostatOrchestrator
+  fan-out + mirror), **#134** (D-Bus logical-thermostat surface), **#135**
+  (terminal UI). E1 remains exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).
-  - "Scene controller thread" (#30) → **E2 / epic #119** (the old #30 stub should
-    be closed or relabelled in favour of #119).
+  - "Scene controller thread" (#30) → **E2 / epic #119** (closed in favour of
+    #119, delivered).
   - "Thermostat management" → **E3**.
 
 ---

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -1969,6 +1969,19 @@ dbus:
       action:
         custom: emitDeleteNodeMetadata
 
+    # Reverse lookup (#132): nodes carrying the exact tag key=value. The
+    # membership resolver for the logical thermostat (#131) — "which nodes
+    # are tagged room=living-room". Returns the node ids as a byte array.
+    - name: GetNodesByMetadata
+      params:
+        - { name: key,   dbus: s, cpp: string }
+        - { name: value, dbus: s, cpp: string }
+      returns:
+        type: bytes
+        dbus: ay
+      action:
+        custom: emitGetNodesByMetadata
+
     # ---- Scene + trigger CRUD (#122) ------------------------------
     # Read/write the durable scene store (#120) over D-Bus. A *scene*
     # crosses the wire as a(yay) — an ordered list of

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1126,9 +1126,13 @@ per network. Distinct from policies (§16b), which are *behavioural*.
 | `SetNodeMetadata` | `(y s s) → ()` | nodeId, key, value; an **empty value clears the key** |
 | `GetNodeMetadata` | `(y) → (a(ss))` | all key/value pairs for a node, ordered by key |
 | `DeleteNodeMetadata` | `(y s) → ()` | clear one key |
+| `GetNodesByMetadata` | `(s s) → (ay)` | **reverse lookup**: node ids carrying the exact tag `key=value`, ascending |
 
 Every Set/Delete emits a `NodeMetadataChanged(y)` signal (retained) so a UI
-can refresh without polling. Example — label node 5:
+can refresh without polling. The reverse lookup (`GetNodesByMetadata`) answers
+"which nodes are tagged `room=living-room`" — the membership resolver the
+logical thermostat (epic #131) builds on. Example — label node 5 and group by
+room:
 
 ```bash
 busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
@@ -1136,6 +1140,9 @@ busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
 busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
     com.tiunda.ZWaved1 GetNodeMetadata y 5
 # → a(ss)  1  "name" "Kitchen light"
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 GetNodesByMetadata ss room "Living room"
+# → ay  2  7 12     (nodes 7 and 12 are tagged room="Living room")
 ```
 
 ## 16d. Scene control (daemon-side scenes)

--- a/TODO.md
+++ b/TODO.md
@@ -54,6 +54,8 @@ Implementation order (each shippable independently):
 
 > [epic: daemon-side closed-loop automation](https://github.com/Assar63/zwaved/issues/101) — daemon *reacts* to node events by *driving* other nodes/CCs (PolicyRegister desired-state re-assertion, verify-after-set, event-triggered cross-node reactions, set/level coalescing, schedules). Orchestrators stay in `src/orchestrator/` (prio 204, bus-only). Full rationale in the issue; broader design context in `FUTURE.md`.
 
+- [ ] [epic: Thermostat management](https://github.com/Assar63/zwaved/issues/131) (FUTURE.md E3) — a **logical thermostat** that fans a Mode/Setpoint Set out to the real climate nodes sharing a node-metadata tag (#83, e.g. `room=living-room`) and mirrors their Reports into an aggregated logical state. Pure orchestration (no virtual nodes). Scoped to **aggregation/mirroring**; closed-loop control (setpoint-vs-measured, schedules) deferred to its own epic. Children: [#132](https://github.com/Assar63/zwaved/issues/132) NodeMetadata reverse lookup, [#133](https://github.com/Assar63/zwaved/issues/133) ThermostatOrchestrator, [#134](https://github.com/Assar63/zwaved/issues/134) D-Bus surface, [#135](https://github.com/Assar63/zwaved/issues/135) terminal UI.
+
 ### Command classes
 
 **Simple — single fixed-shape payload, mirrors the existing BinarySwitch / Association pattern:**

--- a/src/external-api/DBusBackend.cpp
+++ b/src/external-api/DBusBackend.cpp
@@ -466,6 +466,14 @@ auto emitDeleteNodeMetadata(DBusBackend::Impl& /*impl*/, std::uint8_t nodeId, co
     NodeMetadata::instance().remove(nodeId, key);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
+auto emitGetNodesByMetadata(DBusBackend::Impl& /*impl*/,
+                            const std::string& key,
+                            const std::string& value) -> std::vector<std::uint8_t>
+{
+    return NodeMetadata::instance().nodesWith(key, value);
+}
+
 // ---- Scene + trigger CRUD (#122) -------------------------------------
 // Thin adapters over SceneStore::instance(). A scene crosses the wire as
 // a(yay) — a list of (targetNodeId, ccPayload) actions; a trigger as

--- a/src/node-metadata/NodeMetadata.cpp
+++ b/src/node-metadata/NodeMetadata.cpp
@@ -40,6 +40,8 @@ constexpr const char* DELETE_SQL     = "DELETE FROM node_metadata WHERE home_id 
 constexpr const char* SELECT_ONE_SQL = "SELECT value FROM node_metadata WHERE home_id = ? AND node_id = ? AND key = ?";
 constexpr const char* SELECT_ALL_SQL =
     "SELECT key, value FROM node_metadata WHERE home_id = ? AND node_id = ? ORDER BY key";
+constexpr const char* SELECT_NODES_BY_TAG_SQL =
+    "SELECT node_id FROM node_metadata WHERE home_id = ? AND key = ? AND value = ? ORDER BY node_id ASC";
 
 auto formatHomeId(const std::vector<std::uint8_t>& bytes) -> std::string
 {
@@ -117,6 +119,10 @@ class Stmt
         }
         const int len = sqlite3_column_bytes(stmt_, col);
         return {text, text + len};
+    }
+    [[nodiscard]] auto columnInt(int col) const -> int
+    {
+        return sqlite3_column_int(stmt_, col);
     }
 
   private:
@@ -275,6 +281,29 @@ auto NodeMetadata::Store::getAll(std::uint8_t nodeId) const -> std::vector<Entry
     while (stmt.step() == SQLITE_ROW)
     {
         out.push_back(Entry{.key = stmt.columnText(0), .value = stmt.columnText(1)});
+    }
+    return out;
+}
+
+auto NodeMetadata::Store::nodesWith(const std::string& key, const std::string& value) const -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> out;
+    const std::scoped_lock lock(state_->mutex);
+    if (state_->db == nullptr || !state_->currentHomeId.has_value())
+    {
+        return out;
+    }
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access): checked above; tidy can't track the short-circuit
+    const std::string& home = *state_->currentHomeId;
+    Stmt stmt(state_->db, SELECT_NODES_BY_TAG_SQL, "SELECT nodes by tag");
+    if (!stmt.valid())
+    {
+        return out;
+    }
+    stmt.bindText(1, home).bindText(2, key).bindText(3, value);
+    while (stmt.step() == SQLITE_ROW)
+    {
+        out.push_back(static_cast<std::uint8_t>(stmt.columnInt(0)));
     }
     return out;
 }

--- a/src/node-metadata/NodeMetadata.hpp
+++ b/src/node-metadata/NodeMetadata.hpp
@@ -57,6 +57,13 @@ class Store
     /// All key/value pairs for `nodeId`, ordered by key.
     [[nodiscard]] auto getAll(std::uint8_t nodeId) const -> std::vector<Entry>;
 
+    /// Reverse lookup: every node in the current network carrying the exact
+    /// tag `key=value`, ascending node id. The membership resolver the
+    /// logical thermostat (#131) builds on — "which nodes are tagged
+    /// `room=living-room`". Empty if none / no DB / no home bound.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): key and value are clearly named at call sites
+    [[nodiscard]] auto nodesWith(const std::string& key, const std::string& value) const -> std::vector<std::uint8_t>;
+
   private:
     struct State;
     std::unique_ptr<State> state_;

--- a/tests/NodeMetadata_test.cpp
+++ b/tests/NodeMetadata_test.cpp
@@ -129,3 +129,43 @@ TEST_F(NodeMetadataTest, PersistsAcrossRestart)
     EXPECT_EQ(*second.get(5, "name"), "Kitchen light");
     EXPECT_EQ(*second.get(5, "purpose"), "main light");
 }
+
+TEST_F(NodeMetadataTest, NodesWithTagReverseLookup)
+{
+    NodeMetadata::Store store(dbPath_);
+    store.setHomeId(kHomeId);
+    store.set(5, "room", "living-room");
+    store.set(8, "room", "living-room");
+    store.set(3, "room", "living-room");
+    store.set(9, "room", "kitchen");
+    store.set(8, "name", "TRV");  // a different key on a member shouldn't matter
+
+    // Ascending node id, only exact (key,value) matches.
+    EXPECT_EQ(store.nodesWith("room", "living-room"), (std::vector<std::uint8_t>{3, 5, 8}));
+    EXPECT_EQ(store.nodesWith("room", "kitchen"), (std::vector<std::uint8_t>{9}));
+    EXPECT_TRUE(store.nodesWith("room", "bathroom").empty());     // no such value
+    EXPECT_TRUE(store.nodesWith("zone", "living-room").empty());  // no such key
+}
+
+TEST_F(NodeMetadataTest, NodesWithIsHomeScoped)
+{
+    const std::vector<std::uint8_t> otherHome{0x11, 0x22, 0x33, 0x44};
+    NodeMetadata::Store store(dbPath_);
+    store.setHomeId(kHomeId);
+    store.set(5, "room", "den");
+
+    store.setHomeId(otherHome);
+    EXPECT_TRUE(store.nodesWith("room", "den").empty());  // other network
+    store.setHomeId(kHomeId);
+    EXPECT_EQ(store.nodesWith("room", "den"), (std::vector<std::uint8_t>{5}));
+}
+
+TEST_F(NodeMetadataTest, NodesWithClearedTagDrops)
+{
+    NodeMetadata::Store store(dbPath_);
+    store.setHomeId(kHomeId);
+    store.set(5, "room", "den");
+    store.set(6, "room", "den");
+    store.set(5, "room", "");  // empty value clears the key
+    EXPECT_EQ(store.nodesWith("room", "den"), (std::vector<std::uint8_t>{6}));
+}


### PR DESCRIPTION
Closes #132. First child of the thermostat-management epic **#131** (FUTURE.md E3).

## What
The membership resolver a logical thermostat is built on. NodeMetadata (#83) was keyed `(home_id, node_id, key)` and only answered "what are node N's tags". This adds the **reverse** direction — "which nodes carry `room=living-room`":

- `NodeMetadata::Store::nodesWith(key, value) → vector<node_id>` — home-scoped, ascending, exact `(key,value)` match. One indexed `SELECT`; adds a small `columnInt()` accessor to the module-local `Stmt` helper.
- D-Bus `GetNodesByMetadata(s key, s value) → ay nodeIds` — a `custom:` emit helper over `NodeMetadata::instance()`, mirroring the existing metadata CRUD.

## Tests / verification
- New: reverse lookup (ascending order, exact match, no-such-key / no-such-value), home-scoping, and that clearing a tag (empty value) drops the node.
- **304/304** tests pass on gnu + llvm; clang-format + clang-tidy clean (pre-commit hook passed).

## Docs
- MANUAL §16c gains the method + a group-by-room `busctl` example.
- FUTURE.md marks E3 filed as epic #131; TODO.md adds the epic with its children (#132–#135).

Next in the epic: #133 ThermostatOrchestrator (fan-out + mirror) consumes this resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)