### PR TITLE
feat: ThermostatOrchestrator — logical thermostat fan-out + mirror (#133)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -274,11 +274,11 @@ governs.
   Basic Set 0x20 + Scene Activation 0x2B, behind a `source` discriminator) ✅.
   Scenes run end-to-end from Central Scene, Basic Set, or Scene Activation
   presses (see MANUAL §16d).
-- **E3 (thermostat management) is filed** as epic **#131**, scoped to
+- **E3 (thermostat management) is in progress** as epic **#131**, scoped to
   aggregation/mirroring (the closed-loop control deferred to its own epic) and
   grouping via node metadata (#83) rather than a new store. Children: **#132**
-  (NodeMetadata reverse lookup / nodes-by-tag), **#133** (ThermostatOrchestrator
-  fan-out + mirror), **#134** (D-Bus logical-thermostat surface), **#135**
+  (NodeMetadata reverse lookup / nodes-by-tag) ✅, **#133** (ThermostatOrchestrator
+  fan-out + mirror) ✅, **#134** (D-Bus logical-thermostat surface), **#135**
   (terminal UI). E1 remains exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -536,6 +536,33 @@ events:
       - { name: mode,         type: u8,   default: 0 }
       - { name: "off",        type: bool, default: false }
 
+  - name: LogicalThermostatState
+    category: transient
+    direction: { publishers: [orchestrator], subscribers: [external-api] }
+    doc: |
+      Aggregated state of a *logical thermostat* (#131/#133) — the climate
+      nodes sharing the node-metadata tag `groupKey=groupValue`. Published by
+      the ThermostatOrchestrator whenever a member's report changes the
+      aggregate. `memberCount` is how many tagged nodes were resolved.
+      `mode` / `fanMode` carry `MODE_MIXED` (0xFF) when members disagree;
+      `operatingState` is "active" (heating/cooling) if any member is.
+      The setpoint fields carry the most-recently-reported member setpoint
+      (with its `setpointType` so the client knows which). Aggregation only
+      — closed-loop control is a separate future epic.
+    constants:
+      - { name: MODE_MIXED, value: 0xFF }
+    fields:
+      - { name: groupKey,          type: string }
+      - { name: groupValue,        type: string }
+      - { name: memberCount,       type: u8,  default: 0 }
+      - { name: mode,              type: u8,  default: 0 }
+      - { name: operatingState,    type: u8,  default: 0 }
+      - { name: fanMode,           type: u8,  default: 0 }
+      - { name: setpointType,      type: u8,  default: 0 }
+      - { name: setpointScale,     type: u8,  default: 0 }
+      - { name: setpointPrecision, type: u8,  default: 0 }
+      - { name: setpointValue,     type: i32, default: 0, doc: "raw; target = value / 10^precision" }
+
   - name: WakeUpIntervalReport
     category: transient
     direction: { publishers: [cc-translator], subscribers: [external-api] }
@@ -1166,6 +1193,36 @@ events:
     fields:
       - { name: nodeId,     type: u8, default: 0 }
       - { name: callbackId, type: u8, default: 0 }
+
+  - name: LogicalThermostatModeCommand
+    category: command
+    direction: { publishers: [external-api], subscribers: [orchestrator] }
+    doc: |
+      Set the thermostat mode of a *logical thermostat* (#131/#133) — every
+      climate node tagged `groupKey=groupValue` that supports Thermostat Mode
+      (CC 0x40). The ThermostatOrchestrator fans this out to one
+      SetThermostatModeCommand per resolved member.
+    fields:
+      - { name: groupKey,   type: string }
+      - { name: groupValue, type: string }
+      - { name: mode,       type: u8, default: 0 }
+
+  - name: LogicalThermostatSetpointCommand
+    category: command
+    direction: { publishers: [external-api], subscribers: [orchestrator] }
+    doc: |
+      Set the setpoint of a *logical thermostat* (#131/#133) — every climate
+      node tagged `groupKey=groupValue` that supports Thermostat Setpoint
+      (CC 0x43). The ThermostatOrchestrator fans this out to one
+      SetThermostatSetpointCommand per resolved member. Raw precision/scale/
+      value encoding, same as the per-node command.
+    fields:
+      - { name: groupKey,     type: string }
+      - { name: groupValue,   type: string }
+      - { name: setpointType, type: u8,  default: 0 }
+      - { name: precision,    type: u8,  default: 0 }
+      - { name: scale,        type: u8,  default: 0 }
+      - { name: value,        type: i32, default: 0, doc: "raw; target = value / 10^precision" }
 
   - name: GetBatteryCommand
     category: command

--- a/src/orchestrator/CMakeLists.txt
+++ b/src/orchestrator/CMakeLists.txt
@@ -10,4 +10,5 @@ target_sources(zwaved PRIVATE
     WakeUpOrchestrator.cpp
     InclusionOrchestrator.cpp
     SceneOrchestrator.cpp
+    ThermostatOrchestrator.cpp
 )

--- a/src/orchestrator/ThermostatOrchestrator.cpp
+++ b/src/orchestrator/ThermostatOrchestrator.cpp
@@ -1,0 +1,340 @@
+// ThermostatOrchestrator (#131/#133) — a *logical thermostat* over real
+// climate devices. A logical thermostat is the set of nodes sharing a
+// node-metadata tag `groupKey=groupValue` (#83 reverse lookup, #132) that
+// support the relevant Thermostat CC. There is no group store: membership is
+// derived from metadata at the moment a command or report is handled.
+//
+// Two directions (aggregation/mirroring only — closed-loop control is a
+// separate future epic):
+//   - fan-out: a LogicalThermostat{Mode,Setpoint}Command resolves members
+//     via NodeMetadata::nodesWith, gates each on Thermostat CC support
+//     (NodeRegistry), and publishes one per-node Set command per member.
+//   - mirror: the four typed Thermostat Reports update an in-memory per-node
+//     cache; for each *known* group (one a client has addressed) the node
+//     belongs to, the aggregate is recomputed and LogicalThermostatState
+//     published when it changes.
+//
+// Loose-coupling rule (same as the other orchestrators): bus-only, owns no
+// thread, reacts synchronously under the recursive bus mutex.
+
+#include "../logger/Logger.hpp"
+#include "../message-bus/MessageBus.hpp"
+#include "../node-metadata/NodeMetadata.hpp"
+#include "../node-registry/NodeRegistry.hpp"
+#include "../zwaved.h"  // IWYU pragma: keep — CONFIG_ORCHESTRATOR_PRIO
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+// Thermostat CC class bytes (InterfaceManifest module wire constants).
+constexpr std::uint8_t CC_THERMOSTAT_MODE            = 0x40;
+constexpr std::uint8_t CC_THERMOSTAT_OPERATING_STATE = 0x42;
+constexpr std::uint8_t CC_THERMOSTAT_SETPOINT        = 0x43;
+constexpr std::uint8_t CC_THERMOSTAT_FAN_MODE        = 0x44;
+
+// Operating-state values (CC 0x42) used for the "any member active" rollup.
+constexpr std::uint8_t OP_STATE_IDLE    = 0;
+constexpr std::uint8_t OP_STATE_HEATING = 1;
+constexpr std::uint8_t OP_STATE_COOLING = 2;
+
+constexpr std::uint8_t NO_CALLBACK = 0x00;
+
+using GroupKey = std::pair<std::string, std::string>;  // (metadata key, value)
+
+struct Setpoint
+{
+    std::uint8_t type      = 0;
+    std::uint8_t scale     = 0;
+    std::uint8_t precision = 0;
+    std::int32_t value     = 0;
+};
+
+// Last-known per-node climate readings, populated from inbound Reports.
+struct NodeClimate
+{
+    std::optional<std::uint8_t> mode;
+    std::optional<std::uint8_t> operatingState;
+    std::optional<std::uint8_t> fanMode;
+    std::optional<Setpoint> setpoint;
+    std::uint64_t setpointSeq = 0;  // ordering for "most-recently-reported"
+};
+
+// NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public members read like a struct
+struct State
+{
+    std::vector<MessageBus::SubscriptionGuard> subs;
+
+    std::map<std::uint8_t, NodeClimate> perNode;    // by node id
+    std::set<GroupKey> knownGroups;                 // groups a client has addressed
+    std::map<GroupKey, std::string> lastSignature;  // change-detection per group
+    std::uint64_t setpointCounter = 0;
+
+    State() = default;
+    ~State()
+    {
+        Logger::info("[ThermostatOrchestrator] shutdown complete");
+    }
+
+    State(const State&)                        = delete;
+    auto operator=(const State&) -> State&     = delete;
+    State(State&&) noexcept                    = delete;
+    auto operator=(State&&) noexcept -> State& = delete;
+};
+// NOLINTEND(misc-non-private-member-variables-in-classes)
+
+auto state() -> State&
+{
+    static State instance;
+    return instance;
+}
+
+// True if `nodeId`'s NodeRegistry entry lists `classByte`. Snapshot is taken
+// by the caller so a single fan-out does one registry copy.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): nodeId and classByte are clearly named at call sites
+auto supportsCc(const std::vector<NodeRegistry::NodeInfo>& nodes, std::uint8_t nodeId, std::uint8_t classByte) -> bool
+{
+    for (const auto& info : nodes)
+    {
+        if (info.nodeId == nodeId)
+        {
+            return std::find(info.commandClasses.begin(), info.commandClasses.end(), classByte) !=
+                   info.commandClasses.end();
+        }
+    }
+    return false;
+}
+
+// ---- Aggregation across a group's members -------------------------------
+
+// Common value across members that reported one, or MIXED if they disagree,
+// or 0 if none reported. `pick` selects the optional field.
+template <typename Pick> auto aggregateByte(const std::vector<std::uint8_t>& members, Pick pick) -> std::uint8_t
+{
+    std::optional<std::uint8_t> common;
+    bool mixed = false;
+    for (const auto member : members)
+    {
+        const auto entry = state().perNode.find(member);
+        if (entry == state().perNode.end())
+        {
+            continue;
+        }
+        const std::optional<std::uint8_t> value = pick(entry->second);
+        if (!value.has_value())
+        {
+            continue;
+        }
+        if (!common.has_value())
+        {
+            common = value;
+        }
+        else if (*common != *value)
+        {
+            mixed = true;
+        }
+    }
+    if (mixed)
+    {
+        return MessageBus::LogicalThermostatState::MODE_MIXED;
+    }
+    return common.value_or(0);
+}
+
+// "Active" rollup: heating if any member is heating, else cooling if any is
+// cooling, else idle.
+auto aggregateOperatingState(const std::vector<std::uint8_t>& members) -> std::uint8_t
+{
+    bool anyCooling = false;
+    for (const auto member : members)
+    {
+        const auto entry = state().perNode.find(member);
+        if (entry == state().perNode.end())
+        {
+            continue;
+        }
+        const std::optional<std::uint8_t>& opState = entry->second.operatingState;
+        if (!opState.has_value())
+        {
+            continue;
+        }
+        if (*opState == OP_STATE_HEATING)
+        {
+            return OP_STATE_HEATING;
+        }
+        if (*opState == OP_STATE_COOLING)
+        {
+            anyCooling = true;
+        }
+    }
+    return anyCooling ? OP_STATE_COOLING : OP_STATE_IDLE;
+}
+
+// The most-recently-reported setpoint among members (by sequence).
+auto aggregateSetpoint(const std::vector<std::uint8_t>& members) -> Setpoint
+{
+    Setpoint best;
+    std::uint64_t bestSeq = 0;
+    for (const auto member : members)
+    {
+        const auto entry = state().perNode.find(member);
+        if (entry == state().perNode.end())
+        {
+            continue;
+        }
+        const std::optional<Setpoint>& setpoint = entry->second.setpoint;
+        if (setpoint.has_value() && entry->second.setpointSeq >= bestSeq)
+        {
+            bestSeq = entry->second.setpointSeq;
+            best    = *setpoint;
+        }
+    }
+    return best;
+}
+
+// Recompute and (if changed) publish the aggregate for one group.
+auto publishGroupState(const GroupKey& group) -> void
+{
+    const std::vector<std::uint8_t> members = NodeMetadata::instance().nodesWith(group.first, group.second);
+    const std::uint8_t mode                 = aggregateByte(members, [](const NodeClimate& node) { return node.mode; });
+    const std::uint8_t fan       = aggregateByte(members, [](const NodeClimate& node) { return node.fanMode; });
+    const std::uint8_t operating = aggregateOperatingState(members);
+    const Setpoint setpoint      = aggregateSetpoint(members);
+
+    const MessageBus::LogicalThermostatState event{
+        .groupKey          = group.first,
+        .groupValue        = group.second,
+        .memberCount       = static_cast<std::uint8_t>(members.size()),
+        .mode              = mode,
+        .operatingState    = operating,
+        .fanMode           = fan,
+        .setpointType      = setpoint.type,
+        .setpointScale     = setpoint.scale,
+        .setpointPrecision = setpoint.precision,
+        .setpointValue     = setpoint.value,
+    };
+
+    // Change-detection so a member report that doesn't move the aggregate
+    // stays quiet.
+    const std::string signature = std::to_string(event.memberCount) + ":" + std::to_string(event.mode) + ":" +
+                                  std::to_string(event.operatingState) + ":" + std::to_string(event.fanMode) + ":" +
+                                  std::to_string(event.setpointType) + ":" + std::to_string(event.setpointScale) + ":" +
+                                  std::to_string(event.setpointPrecision) + ":" + std::to_string(event.setpointValue);
+    auto& last = state().lastSignature[group];
+    if (last == signature)
+    {
+        return;
+    }
+    last = signature;
+    MessageBus::publish(event);
+}
+
+// After a member report, refresh every known group the node belongs to.
+auto refreshGroupsForNode(std::uint8_t nodeId) -> void
+{
+    for (const auto& group : state().knownGroups)
+    {
+        const std::vector<std::uint8_t> members = NodeMetadata::instance().nodesWith(group.first, group.second);
+        if (std::find(members.begin(), members.end(), nodeId) != members.end())
+        {
+            publishGroupState(group);
+        }
+    }
+}
+
+// ---- Fan-out (logical Set -> per-node Sets) ------------------------------
+
+auto onModeCommand(const MessageBus::LogicalThermostatModeCommand& cmd) -> void
+{
+    state().knownGroups.insert({cmd.groupKey, cmd.groupValue});
+    const std::vector<std::uint8_t> members         = NodeMetadata::instance().nodesWith(cmd.groupKey, cmd.groupValue);
+    const std::vector<NodeRegistry::NodeInfo> nodes = NodeRegistry::snapshot();
+    std::uint32_t fanned                            = 0;
+    for (const auto member : members)
+    {
+        if (!supportsCc(nodes, member, CC_THERMOSTAT_MODE))
+        {
+            continue;
+        }
+        MessageBus::publish(
+            MessageBus::SetThermostatModeCommand{.nodeId = member, .mode = cmd.mode, .callbackId = NO_CALLBACK});
+        ++fanned;
+    }
+    Logger::info("[ThermostatOrchestrator] mode " + std::to_string(cmd.mode) + " -> group '" + cmd.groupKey + "=" +
+                 cmd.groupValue + "' (" + std::to_string(fanned) + " member(s))");
+}
+
+auto onSetpointCommand(const MessageBus::LogicalThermostatSetpointCommand& cmd) -> void
+{
+    state().knownGroups.insert({cmd.groupKey, cmd.groupValue});
+    const std::vector<std::uint8_t> members         = NodeMetadata::instance().nodesWith(cmd.groupKey, cmd.groupValue);
+    const std::vector<NodeRegistry::NodeInfo> nodes = NodeRegistry::snapshot();
+    std::uint32_t fanned                            = 0;
+    for (const auto member : members)
+    {
+        if (!supportsCc(nodes, member, CC_THERMOSTAT_SETPOINT))
+        {
+            continue;
+        }
+        MessageBus::publish(MessageBus::SetThermostatSetpointCommand{
+            .nodeId       = member,
+            .setpointType = cmd.setpointType,
+            .precision    = cmd.precision,
+            .scale        = cmd.scale,
+            .value        = cmd.value,
+            .callbackId   = NO_CALLBACK,
+        });
+        ++fanned;
+    }
+    Logger::info("[ThermostatOrchestrator] setpoint type " + std::to_string(cmd.setpointType) + " -> group '" +
+                 cmd.groupKey + "=" + cmd.groupValue + "' (" + std::to_string(fanned) + " member(s))");
+}
+
+// ---- Mirror (per-node report -> logical state) ---------------------------
+
+auto onModeReport(const MessageBus::ThermostatModeReport& report) -> void
+{
+    state().perNode[report.sourceNodeId].mode = report.mode;
+    refreshGroupsForNode(report.sourceNodeId);
+}
+
+auto onOperatingStateReport(const MessageBus::ThermostatOperatingStateReport& report) -> void
+{
+    state().perNode[report.sourceNodeId].operatingState = report.state;
+    refreshGroupsForNode(report.sourceNodeId);
+}
+
+auto onFanModeReport(const MessageBus::ThermostatFanModeReport& report) -> void
+{
+    state().perNode[report.sourceNodeId].fanMode = report.mode;
+    refreshGroupsForNode(report.sourceNodeId);
+}
+
+auto onSetpointReport(const MessageBus::ThermostatSetpointReport& report) -> void
+{
+    NodeClimate& node = state().perNode[report.sourceNodeId];
+    node.setpoint     = Setpoint{
+            .type = report.setpointType, .scale = report.scale, .precision = report.precision, .value = report.value};
+    node.setpointSeq = ++state().setpointCounter;
+    refreshGroupsForNode(report.sourceNodeId);
+}
+
+__attribute__((constructor(CONFIG_ORCHESTRATOR_PRIO))) auto startThermostatOrchestrator() -> void
+{
+    auto& subs = state().subs;
+    subs.emplace_back(MessageBus::subscribe<MessageBus::LogicalThermostatModeCommand>(onModeCommand));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::LogicalThermostatSetpointCommand>(onSetpointCommand));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::ThermostatModeReport>(onModeReport));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::ThermostatOperatingStateReport>(onOperatingStateReport));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::ThermostatFanModeReport>(onFanModeReport));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::ThermostatSetpointReport>(onSetpointReport));
+    Logger::info("[ThermostatOrchestrator] managing logical thermostats");
+}
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -583,6 +583,32 @@ target_link_libraries(SceneOrchestrator_test PRIVATE
 zwaved_test_target(SceneOrchestrator_test)
 gtest_discover_tests(SceneOrchestrator_test)
 
+# ---- ThermostatOrchestrator -----------------------------------------
+add_executable(ThermostatOrchestrator_test
+    ThermostatOrchestrator_test.cpp
+    "${CMAKE_SOURCE_DIR}/src/orchestrator/ThermostatOrchestrator.cpp"
+    "${CMAKE_SOURCE_DIR}/src/node-metadata/NodeMetadata.cpp"
+    "${CMAKE_SOURCE_DIR}/src/node-registry/NodeRegistry.cpp"
+    "${CMAKE_SOURCE_DIR}/src/logger/Logger.cpp"
+    "${CMAKE_SOURCE_DIR}/src/message-bus/MessageBus.cpp"
+    "${ZWAVED_GENERATED_DIR}/MessageBus.gen.cpp"
+)
+target_include_directories(ThermostatOrchestrator_test PRIVATE
+    "${CMAKE_SOURCE_DIR}/src/node-metadata"
+    "${CMAKE_SOURCE_DIR}/src/node-registry"
+    "${CMAKE_SOURCE_DIR}/src/message-bus"
+    "${ZWAVED_GENERATED_DIR}"
+)
+add_dependencies(ThermostatOrchestrator_test zwaved_codegen)
+target_link_libraries(ThermostatOrchestrator_test PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    PkgConfig::SQLITE3
+    eventpp::eventpp
+)
+zwaved_test_target(ThermostatOrchestrator_test)
+gtest_discover_tests(ThermostatOrchestrator_test)
+
 # ---- InclusionOrchestrator ------------------------------------------
 # Bus-driven: publishes NodeIncluded, asserts on the lifeline + policy
 # command sequence. Links the orchestrator (armed by its constructor),

--- a/tests/ThermostatOrchestrator_test.cpp
+++ b/tests/ThermostatOrchestrator_test.cpp
@@ -1,0 +1,171 @@
+#include "MessageBus.hpp"
+#include "NodeMetadata.hpp"
+#include "NodeRegistry.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Bus-driven test for ThermostatOrchestrator (#133). No live dongle: we tag
+// nodes via NodeMetadata, register their CC support in NodeRegistry, then
+// publish LogicalThermostat*Commands (assert the per-node Set fan-out) and
+// Thermostat Reports (assert the aggregated LogicalThermostatState).
+//
+// The orchestrator arms its subscriptions via __attribute__((constructor)) at
+// load, so linking ThermostatOrchestrator.cpp is enough. NodeMetadata uses a
+// StorageConfig-resolved DB path; NodeRegistry shares the same nodes.db.
+// Singleton state (perNode cache, knownGroups) persists across cases, so each
+// test uses distinct node ids and room values to stay independent.
+
+namespace
+{
+using MessageBus::SubscriptionGuard;
+
+const std::vector<std::uint8_t> kHomeId{0xE2, 0xA1, 0xB0, 0x7C};
+
+constexpr std::uint8_t CC_MODE     = 0x40;
+constexpr std::uint8_t CC_SETPOINT = 0x43;
+
+auto registerNode(std::uint8_t nodeId, const std::vector<std::uint8_t>& ccs) -> void
+{
+    NodeRegistry::add(NodeRegistry::NodeInfo{
+        .nodeId = nodeId, .basicType = 0x04, .genericType = 0x08, .specificType = 0x06, .commandClasses = ccs});
+}
+
+struct Recorder
+{
+    std::vector<std::string> log;
+    std::vector<SubscriptionGuard> guards;
+
+    Recorder()
+    {
+        guards.emplace_back(MessageBus::subscribe<MessageBus::SetThermostatModeCommand>(
+            [this](const MessageBus::SetThermostatModeCommand& cmd)
+            { log.push_back("mode:" + std::to_string(cmd.nodeId) + ":" + std::to_string(cmd.mode)); }));
+        guards.emplace_back(MessageBus::subscribe<MessageBus::SetThermostatSetpointCommand>(
+            [this](const MessageBus::SetThermostatSetpointCommand& cmd)
+            {
+                log.push_back("sp:" + std::to_string(cmd.nodeId) + ":" + std::to_string(cmd.setpointType) + ":" +
+                              std::to_string(cmd.value));
+            }));
+        guards.emplace_back(MessageBus::subscribe<MessageBus::LogicalThermostatState>(
+            [this](const MessageBus::LogicalThermostatState& evt)
+            {
+                log.push_back("state:" + evt.groupValue + ":n" + std::to_string(evt.memberCount) + ":mode" +
+                              std::to_string(evt.mode) + ":op" + std::to_string(evt.operatingState) + ":sp" +
+                              std::to_string(evt.setpointValue));
+            }));
+    }
+};
+
+class ThermostatOrchestratorTest : public ::testing::Test
+{
+  protected:
+    static void SetUpTestSuite()
+    {
+        const auto unique = std::to_string(::getpid()) + "-" + std::to_string(std::random_device{}());
+        dbPath_           = std::filesystem::temp_directory_path() / ("zwaved-thermo-test-" + unique + ".db");
+        MessageBus::publish(MessageBus::StorageConfig{.stateDir = dbPath_.parent_path().string()});
+        NodeMetadata::instance().setHomeId(kHomeId);
+        NodeRegistry::setHomeId(kHomeId);
+    }
+
+    static void TearDownTestSuite()
+    {
+        std::error_code errorCode;
+        std::filesystem::remove(dbPath_, errorCode);
+    }
+
+    static std::filesystem::path dbPath_;
+};
+
+std::filesystem::path ThermostatOrchestratorTest::dbPath_;
+}  // namespace
+
+TEST_F(ThermostatOrchestratorTest, ModeFansOutOnlyToSupportingMembers)
+{
+    // Nodes 5 and 6 are in the living room; 5 is a thermostat, 6 is a plug.
+    NodeMetadata::instance().set(5, "room", "lr-mode");
+    NodeMetadata::instance().set(6, "room", "lr-mode");
+    registerNode(5, {CC_MODE, CC_SETPOINT});
+    registerNode(6, {0x25});  // Binary Switch only — must be skipped
+
+    Recorder rec;
+    MessageBus::publish(
+        MessageBus::LogicalThermostatModeCommand{.groupKey = "room", .groupValue = "lr-mode", .mode = 1});
+
+    ASSERT_EQ(rec.log.size(), 1U);
+    EXPECT_EQ(rec.log[0], "mode:5:1");  // only node 5 (supports CC 0x40)
+}
+
+TEST_F(ThermostatOrchestratorTest, SetpointFansOutToSupportingMembers)
+{
+    NodeMetadata::instance().set(10, "room", "lr-sp");
+    NodeMetadata::instance().set(11, "room", "lr-sp");
+    registerNode(10, {CC_MODE, CC_SETPOINT});
+    registerNode(11, {CC_SETPOINT});
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::LogicalThermostatSetpointCommand{
+        .groupKey = "room", .groupValue = "lr-sp", .setpointType = 1, .precision = 1, .scale = 0, .value = 215});
+
+    ASSERT_EQ(rec.log.size(), 2U);
+    EXPECT_EQ(rec.log[0], "sp:10:1:215");
+    EXPECT_EQ(rec.log[1], "sp:11:1:215");
+}
+
+TEST_F(ThermostatOrchestratorTest, EmptyGroupFansOutNothing)
+{
+    Recorder rec;
+    MessageBus::publish(
+        MessageBus::LogicalThermostatModeCommand{.groupKey = "room", .groupValue = "nobody-home", .mode = 2});
+    EXPECT_TRUE(rec.log.empty());  // no members → no Set commands
+}
+
+TEST_F(ThermostatOrchestratorTest, MirrorsAgreedModeAndDetectsMixed)
+{
+    NodeMetadata::instance().set(20, "room", "lr-mirror");
+    NodeMetadata::instance().set(21, "room", "lr-mirror");
+    registerNode(20, {CC_MODE});
+    registerNode(21, {CC_MODE});
+
+    Recorder rec;
+    // Address the group once so the orchestrator tracks it.
+    MessageBus::publish(
+        MessageBus::LogicalThermostatModeCommand{.groupKey = "room", .groupValue = "lr-mirror", .mode = 1});
+    rec.log.clear();
+
+    // Both report heat (1) → aggregate mode 1.
+    MessageBus::publish(MessageBus::ThermostatModeReport{.sourceNodeId = 20, .mode = 1});
+    MessageBus::publish(MessageBus::ThermostatModeReport{.sourceNodeId = 21, .mode = 1});
+    // 21 switches to cool (2) → aggregate now MIXED (0xFF).
+    MessageBus::publish(MessageBus::ThermostatModeReport{.sourceNodeId = 21, .mode = 2});
+
+    ASSERT_EQ(rec.log.size(), 2U);  // first report sets mode1; third makes it mixed (second is a no-op change)
+    EXPECT_EQ(rec.log[0], "state:lr-mirror:n2:mode1:op0:sp0");
+    EXPECT_EQ(rec.log[1], "state:lr-mirror:n2:mode255:op0:sp0");  // MODE_MIXED
+}
+
+TEST_F(ThermostatOrchestratorTest, OperatingStateActiveIfAnyMemberHeating)
+{
+    NodeMetadata::instance().set(30, "room", "lr-op");
+    NodeMetadata::instance().set(31, "room", "lr-op");
+    registerNode(30, {CC_MODE});
+    registerNode(31, {CC_MODE});
+
+    Recorder rec;
+    MessageBus::publish(MessageBus::LogicalThermostatModeCommand{.groupKey = "room", .groupValue = "lr-op", .mode = 1});
+    rec.log.clear();
+
+    // 30 idle, 31 heating → group operating state = heating (1).
+    MessageBus::publish(MessageBus::ThermostatOperatingStateReport{.sourceNodeId = 30, .state = 0});
+    MessageBus::publish(MessageBus::ThermostatOperatingStateReport{.sourceNodeId = 31, .state = 1});
+
+    ASSERT_FALSE(rec.log.empty());
+    EXPECT_EQ(rec.log.back(), "state:lr-op:n2:mode0:op1:sp0");
+}


### PR DESCRIPTION
Closes #133. Second child of the thermostat-management epic **#131** (FUTURE.md E3), built on the #132 reverse lookup.

## What
A **logical thermostat** is the set of nodes sharing a node-metadata tag `groupKey=groupValue` (#132) that support the relevant Thermostat CC — **no group store**; membership is derived from metadata at handling time. The orchestrator is bus-only (prio 204), same family as the Scene/WakeUp/Inclusion orchestrators.

### New bus events
- `LogicalThermostatModeCommand` / `LogicalThermostatSetpointCommand` (external-api → orchestrator) — address a logical thermostat.
- `LogicalThermostatState` (orchestrator → external-api) — aggregated state, with a `MODE_MIXED` (0xFF) sentinel.

### Two directions
- **Fan-out**: resolve members via `NodeMetadata::nodesWith`, gate each on Thermostat CC support (`NodeRegistry` snapshot), publish one per-node `Set{Mode,Setpoint}Command` per supporting member.
- **Mirror**: the four typed Thermostat Reports update an in-memory per-node cache; for each *known* group (one a client has addressed) the reporting node belongs to, recompute the aggregate and publish `LogicalThermostatState` on change. Aggregation: mode/fan = common value or `MIXED`; operating state = active if any member heating/cooling; setpoint = most-recently-reported member setpoint.

Aggregation/mirroring **only** — closed-loop control (setpoint vs measured temperature, schedules) stays deferred to its own epic.

## Tests / verification
- 5 bus-driven cases: CC-gated mode + setpoint fan-out, empty group, agreed-vs-mixed mode mirror, operating-state rollup.
- **309/309** tests pass on gnu + llvm; clang-format + clang-tidy clean (pre-commit hook passed).

## Docs
- FUTURE.md marks epic #131 children #132/#133 done.
- The client-facing D-Bus surface (`SetLogicalThermostat*` / `GetLogicalThermostatState` + the `LogicalThermostatStateChanged` signal) is the next child, **#134**, which publishes the command events this orchestrator consumes and emits the state event as a signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)