### PR TITLE
ci: cap GNU Docker build to 2 parallel jobs (fix OOM stall)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,8 +139,15 @@ FROM toolchain AS build
 
 WORKDIR /src
 COPY . .
+# Cap the GNU build to 2 parallel jobs. Unbounded `--parallel` (= nproc)
+# runs nproc concurrent g++ processes; GCC 15 compiling the large generated
+# MessageBus.gen.cpp (built once per GoogleTest executable) peaks at well
+# over 1 GB each, and as the test suite grows nproc × that exceeds the
+# CI runner's ~7 GB, so the OOM killer silently takes a cc1plus mid-build
+# and the job stalls/dies with no diagnostic. clang (the build-llvm stage)
+# is lighter and hasn't hit this, so it stays uncapped; revisit if it does.
 RUN cmake --preset gnu \
-    && cmake --build cmake-build-gnu --parallel \
+    && cmake --build cmake-build-gnu --parallel 2 \
     && ctest --test-dir cmake-build-gnu --output-on-failure
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The **build-and-test (gnu)** CI job has been stalling and getting killed mid-build with no diagnostic — silent for minutes after ~85%, then `Cleaning up orphan processes`. Meanwhile **build-and-test-llvm** passes full build + ctest (309/309) and local gnu builds are green. It started reproducing reliably once the suite crossed ~60 test executables (the #133 ThermostatOrchestrator_test was the tipping point), failing on both the PR branch and master.

## Diagnosis
Classic OOM-killer signature: the Docker `build` stage runs `cmake --build cmake-build-gnu --parallel` (= `nproc` jobs). GCC 15 compiling the large generated `MessageBus.gen.cpp` — built once per GoogleTest executable — peaks well over 1 GB per `cc1plus`. `nproc × peak` exceeds the GitHub runner's ~7 GB, so the kernel kills a `cc1plus` mid-compile; `make` hangs on the dead child and the job is eventually torn down. No `error:` is printed because the process is SIGKILLed. clang uses less RAM per TU, so build-llvm never tripped it.

## Fix
Cap the gnu build to `--parallel 2`, bounding peak memory. build-llvm stays uncapped (lighter, healthy) — easy to give it the same treatment if it ever stalls.

## Validation
Can't reproduce locally (dev box has more RAM), so **this PR's own CI run is the test** — the gnu job going green confirms the fix. Unblocks master CI (currently red from this same stall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)