### PR TITLE
feat: D-Bus logical-thermostat surface (#134)

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -278,7 +278,7 @@ governs.
   aggregation/mirroring (the closed-loop control deferred to its own epic) and
   grouping via node metadata (#83) rather than a new store. Children: **#132**
   (NodeMetadata reverse lookup / nodes-by-tag) ✅, **#133** (ThermostatOrchestrator
-  fan-out + mirror) ✅, **#134** (D-Bus logical-thermostat surface), **#135**
+  fan-out + mirror) ✅, **#134** (D-Bus logical-thermostat surface) ✅, **#135**
   (terminal UI). E1 remains exploratory here.
 - Old TODO.md stubs are superseded by this doc:
   - "Virtual nodes" (#29) → **E1** (addressable presence).

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -2112,6 +2112,49 @@ dbus:
       action:
         custom: emitListSceneTriggers
 
+    # ---- Logical thermostat (#131/#134) ---------------------------
+    # Drive and read a *logical thermostat* — the climate nodes sharing
+    # the node-metadata tag groupKey=groupValue (#83/#132). The Set
+    # methods publish the command events the ThermostatOrchestrator
+    # (#133) fans out; GetLogicalThermostatState reads the backend's
+    # per-group cache of the LogicalThermostatState event (zeros if the
+    # group hasn't been addressed and reported yet).
+    - name: SetLogicalThermostatMode
+      params:
+        - { name: groupKey,   dbus: s, cpp: string }
+        - { name: groupValue, dbus: s, cpp: string }
+        - { name: mode,       dbus: y, cpp: u8 }
+      action:
+        custom: emitSetLogicalThermostatMode
+
+    - name: SetLogicalThermostatSetpoint
+      params:
+        - { name: groupKey,     dbus: s, cpp: string }
+        - { name: groupValue,   dbus: s, cpp: string }
+        - { name: setpointType, dbus: y, cpp: u8 }
+        - { name: precision,    dbus: y, cpp: u8 }
+        - { name: scale,        dbus: y, cpp: u8 }
+        - { name: value,        dbus: i, cpp: i32 }
+      action:
+        custom: emitSetLogicalThermostatSetpoint
+
+    - name: GetLogicalThermostatState
+      params:
+        - { name: groupKey,   dbus: s, cpp: string }
+        - { name: groupValue, dbus: s, cpp: string }
+      returns:
+        struct:
+          - { name: memberCount,       dbus: y, source: cached.LogicalThermostatState.memberCount }
+          - { name: mode,              dbus: y, source: cached.LogicalThermostatState.mode }
+          - { name: operatingState,    dbus: y, source: cached.LogicalThermostatState.operatingState }
+          - { name: fanMode,           dbus: y, source: cached.LogicalThermostatState.fanMode }
+          - { name: setpointType,      dbus: y, source: cached.LogicalThermostatState.setpointType }
+          - { name: setpointScale,     dbus: y, source: cached.LogicalThermostatState.setpointScale }
+          - { name: setpointPrecision, dbus: y, source: cached.LogicalThermostatState.setpointPrecision }
+          - { name: setpointValue,     dbus: i, source: cached.LogicalThermostatState.setpointValue }
+      action:
+        custom: emitGetLogicalThermostatState
+
   # ---- 3b. Signals ------------------------------------------------
   # Each signal is triggered by one or more MessageBus events. The
   # default mapping copies named fields straight through; CC-decoder
@@ -2492,6 +2535,21 @@ dbus:
         - { name: actionCount,  dbus: u }
       triggered_by:
         event: SceneActivated
+
+    - name: LogicalThermostatStateChanged
+      params:
+        - { name: groupKey,          dbus: s }
+        - { name: groupValue,        dbus: s }
+        - { name: memberCount,       dbus: y }
+        - { name: mode,              dbus: y, doc: "0xFF = members disagree (mixed)" }
+        - { name: operatingState,    dbus: y }
+        - { name: fanMode,           dbus: y, doc: "0xFF = members disagree (mixed)" }
+        - { name: setpointType,      dbus: y }
+        - { name: setpointScale,     dbus: y }
+        - { name: setpointPrecision, dbus: y }
+        - { name: setpointValue,     dbus: i }
+      triggered_by:
+        event: LogicalThermostatState
 
 # =====================================================================
 # 4. Protocol modules

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1227,6 +1227,50 @@ lands in the activity pane — e.g. `SceneActivated node=7 scene=1 1x -> "tv" (2
 actions)`; inbound `BasicSetReceived` / `SceneActivationSet` frames are logged
 there too.
 
+## 16e. Logical thermostats (climate-group control)
+
+A **logical thermostat** is the set of climate nodes that share a node-metadata
+tag (§16c) — e.g. every node with `room = Living room`. Writing a mode or
+setpoint to the logical thermostat fans it out to all tagged members that
+support the relevant Thermostat CC; member reports are aggregated back into one
+logical state. Pure orchestration (no virtual node); membership is *derived*
+from metadata at call time, so re-tagging a node moves it between thermostats
+with no extra bookkeeping. Aggregation only — closed-loop control (setpoint vs
+measured temperature, schedules) is a separate future epic.
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `SetLogicalThermostatMode` | `(s s y) → ()` | groupKey, groupValue, mode → fans out a Thermostat Mode Set to each member supporting CC 0x40 |
+| `SetLogicalThermostatSetpoint` | `(s s y y y i) → ()` | groupKey, groupValue, setpointType, precision, scale, value → fans out to members supporting CC 0x43 |
+| `GetLogicalThermostatState` | `(s s) → (y y y y y y y i)` | aggregated (memberCount, mode, operatingState, fanMode, setpointType, setpointScale, setpointPrecision, setpointValue) |
+
+Aggregation rules: `mode` / `fanMode` report the common member value, or `0xFF`
+(**mixed**) when members disagree; `operatingState` is "active"
+(heating/cooling) if any member is; the setpoint fields carry the
+most-recently-reported member setpoint. `memberCount` distinguishes "no members
+tagged" from "idle". A `GetLogicalThermostatState` for a group that hasn't been
+addressed *and* had a member report yet returns all-zeros.
+
+Whenever the aggregate changes, the daemon emits
+`LogicalThermostatStateChanged(s s y y y y y y y i)` — the group identity
+followed by the same aggregated fields — so a UI can track every logical
+thermostat without polling.
+
+Example — drive all `room = Living room` thermostats to heat (mode 1) and 21.5 °C
+(setpoint type 1 heating, precision 1, scale 0 = °C, raw value 215):
+
+```bash
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 SetLogicalThermostatMode ssy room "Living room" 1
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 SetLogicalThermostatSetpoint ssyyyi room "Living room" 1 1 0 215
+busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+    com.tiunda.ZWaved1 GetLogicalThermostatState ss room "Living room"
+# → y y y y y y y i   2 1 1 0 1 0 1 215   (2 members, mode heat, heating, …, 21.5°C)
+```
+
+(Tag members first with `SetNodeMetadata` / group with `GetNodesByMetadata`, §16c.)
+
 ## 17. Future: ubus
 
 A second backend implementing the same methods/signals over OpenWrt's

--- a/scripts/codegen/targets/dbus_methods.py
+++ b/scripts/codegen/targets/dbus_methods.py
@@ -64,7 +64,7 @@ def cpp_param_type(param: DBusParam) -> str:
     return _dbus_to_cpp(param.dbus)
 
 
-PRIMITIVE_PARAM_TYPES = {"bool", "std::uint8_t", "std::uint16_t", "std::uint32_t", "std::uint64_t"}
+PRIMITIVE_PARAM_TYPES = {"bool", "std::uint8_t", "std::uint16_t", "std::uint32_t", "std::uint64_t", "std::int32_t"}
 
 
 def cpp_param_decl(param: DBusParam) -> str:
@@ -132,6 +132,7 @@ RETURN_TUPLE_ALIASES: dict[str, str] = {
     "GetNodeMetadata":    "NodeMetadataTuple",
     "GetScene":           "SceneActionEntry",
     "ListSceneTriggers":  "SceneTriggerEntry",
+    "GetLogicalThermostatState": "LogicalThermostatStateTuple",
 }
 
 

--- a/src/external-api/DBusBackend.cpp
+++ b/src/external-api/DBusBackend.cpp
@@ -94,7 +94,7 @@ auto DBusBackend::run(const std::atomic<bool>& running) -> void
     auto& obj = *impl->object;
 
     // Methods + signals are emitted from InterfaceManifest.yml by
-    // scripts/codegen/. The five hand-written cache-update
+    // scripts/codegen/. The hand-written cache-update
     // subscribers below feed impl->last* state for the
     // `custom: emitGet*` handlers; subscribeGeneratedSignals()
     // appends the signal-emission subscribers, which run after the
@@ -140,6 +140,12 @@ auto DBusBackend::run(const std::atomic<bool>& running) -> void
         {
             std::scoped_lock const lock(impl->stateMutex);
             impl->lastDaemonError = error;
+        }));
+    subs.emplace_back(MessageBus::subscribe<MessageBus::LogicalThermostatState>(
+        [this](const MessageBus::LogicalThermostatState& state) -> void
+        {
+            std::scoped_lock const lock(impl->stateMutex);
+            impl->lastLogicalThermostat[{state.groupKey, state.groupValue}] = state;
         }));
 
     subscribeGeneratedSignals(*impl);
@@ -556,5 +562,60 @@ auto emitListSceneTriggers(DBusBackend::Impl& /*impl*/) -> std::vector<SceneTrig
             trigger.source, trigger.sourceNodeId, trigger.sceneNumber, trigger.keyAttribute, trigger.sceneId);
     }
     return out;
+}
+
+// ---- Logical thermostat (#134) ---------------------------------------
+// Set* publish the command events the ThermostatOrchestrator (#133) fans
+// out; GetLogicalThermostatState reads the per-group cache fed by the
+// LogicalThermostatState subscriber in run().
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
+auto emitSetLogicalThermostatMode(DBusBackend::Impl& /*impl*/,
+                                  const std::string& groupKey,
+                                  const std::string& groupValue,
+                                  std::uint8_t mode) -> void
+{
+    MessageBus::publish(
+        MessageBus::LogicalThermostatModeCommand{.groupKey = groupKey, .groupValue = groupValue, .mode = mode});
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): wire signature is fixed by the D-Bus method
+auto emitSetLogicalThermostatSetpoint(DBusBackend::Impl& /*impl*/,
+                                      const std::string& groupKey,
+                                      const std::string& groupValue,
+                                      std::uint8_t setpointType,
+                                      std::uint8_t precision,
+                                      std::uint8_t scale,
+                                      std::int32_t value) -> void
+{
+    MessageBus::publish(MessageBus::LogicalThermostatSetpointCommand{
+        .groupKey     = groupKey,
+        .groupValue   = groupValue,
+        .setpointType = setpointType,
+        .precision    = precision,
+        .scale        = scale,
+        .value        = value,
+    });
+}
+
+auto emitGetLogicalThermostatState(DBusBackend::Impl& impl,
+                                   const std::string& groupKey,
+                                   const std::string& groupValue) -> LogicalThermostatStateTuple
+{
+    std::scoped_lock const lock(impl.stateMutex);
+    const auto entry = impl.lastLogicalThermostat.find({groupKey, groupValue});
+    if (entry == impl.lastLogicalThermostat.end())
+    {
+        return LogicalThermostatStateTuple{0, 0, 0, 0, 0, 0, 0, 0};
+    }
+    const auto& state = entry->second;
+    return LogicalThermostatStateTuple{state.memberCount,
+                                       state.mode,
+                                       state.operatingState,
+                                       state.fanMode,
+                                       state.setpointType,
+                                       state.setpointScale,
+                                       state.setpointPrecision,
+                                       state.setpointValue};
 }
 }  // namespace ExternalApi

--- a/src/external-api/DBusBackendInternal.hpp
+++ b/src/external-api/DBusBackendInternal.hpp
@@ -9,9 +9,11 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdbus-c++/IConnection.h>
@@ -72,6 +74,19 @@ using SceneTriggerEntry = sdbus::Struct<std::uint8_t, std::uint8_t, std::uint8_t
 
 using DaemonErrorTuple = sdbus::Struct<std::uint8_t, std::string, std::uint8_t, std::string>;
 
+// GetLogicalThermostatState return: (memberCount, mode, operatingState,
+// fanMode, setpointType, setpointScale, setpointPrecision, setpointValue) —
+// the aggregated logical-thermostat state (#134). mode/fanMode carry 0xFF
+// when members disagree.
+using LogicalThermostatStateTuple = sdbus::Struct<std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::uint8_t,
+                                                  std::int32_t>;
+
 using NetworkStatusTuple = sdbus::Struct<bool,
                                          std::string,
                                          std::string,
@@ -114,6 +129,11 @@ struct DBusBackend::Impl
     std::vector<MessageBus::NodeInfo> lastNodes;
     MessageBus::SessionStatus lastSessionStatus;
     MessageBus::DaemonError lastDaemonError;
+
+    // Per-group cache of the latest LogicalThermostatState (#134), keyed by
+    // (groupKey, groupValue), fed by a cache subscriber. GetLogicalThermostat
+    // State reads it; a group not yet addressed+reported returns zeros.
+    std::map<std::pair<std::string, std::string>, MessageBus::LogicalThermostatState> lastLogicalThermostat;
 
     // Captured the first time `run()` is called; powers the uptime
     // field of GetNetworkStatus. steady_clock so it doesn't jump


### PR DESCRIPTION
Closes #134. Third child of the thermostat-management epic **#131** (FUTURE.md E3) — the client-facing surface for the logical thermostat the ThermostatOrchestrator (#133) coordinates.

## Methods (`custom:` emit helpers)
- `SetLogicalThermostatMode(s s y)` / `SetLogicalThermostatSetpoint(s s y y y i)` — publish the `LogicalThermostat{Mode,Setpoint}Command` events #133 fans out to metadata-tagged members.
- `GetLogicalThermostatState(s s) → (y y y y y y y i)` — reads a new **per-group cache** (`map` keyed by `(groupKey, groupValue)`) fed by a `LogicalThermostatState` cache subscriber in `run()`; returns zeros for a group not yet addressed + reported.

## Signal
`LogicalThermostatStateChanged(s s y y y y y y y i)` — triggered by the `LogicalThermostatState` bus event.

## Codegen fix
Added `std::int32_t` to `PRIMITIVE_PARAM_TYPES` so `i32` method params pass **by value** (matching the hand-written emit signature) rather than `const&`. The only custom method with an `i32` param is the new `SetLogicalThermostatSetpoint`, so no other handler changes.

## Tests / verification
- Both compilers build clean; **309/309** tests pass; clang-format + clang-tidy clean.
- No backend-layer unit test — matches the #122 / #132 CRUD precedent (logic lives in the orchestrator #133 + store, both tested).

## Docs
- MANUAL **§16e** documents the methods, aggregation/mixed semantics, and `busctl` examples.
- FUTURE.md marks epic #131 child #134 done — only **#135** (terminal UI) remains.

Branch rebased onto master so it includes #138's `--parallel 2` Docker fix (this PR's CI should build cleanly rather than OOM-stalling).

> Follow-up noted from the CI-stall investigation: the real fix for build memory/time is compiling the bus core (`MessageBus.gen.cpp` — a 245-line source that emits a **25 MB** object from 203 template instantiations, recompiled in 9 test exes) **once into a static library**. Happy to file that as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)