### PR TITLE
feat: Multi Channel (CC 0x60) encap/decap codec (#144)

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -3336,6 +3336,35 @@ modules:
       - { name: GroupingsGet,    wire: { byte: 0x05 } }
       - { name: GroupingsReport, wire: { byte: 0x06 } }
 
+  - name: MultiChannel
+    wire:
+      class_byte: 0x60
+      prefix: MULTI_CHANNEL
+    description: |
+      Multi Channel (CC 0x60) encapsulation layer (E1 Tier 2, #144). Wraps
+      an inner Command Class frame with a source + destination endpoint so a
+      single node can present several addressable endpoints. Only the v2+
+      MULTI_CHANNEL_CMD_ENCAP (0x0D) is handled. The encap/decap is
+      hand-written (variable-length inner payload) in MultiChannel.cpp; the
+      manifest contributes the command byte + endpoint-field masks. Inbound
+      decap feeds the endpoint routing (#146); encode wraps an outbound
+      endpoint-addressed frame.
+    constants:
+      # Endpoint fields: low 7 bits are the endpoint, bit 7 of the
+      # destination byte is the "bit address" flag (multicast to a bitmask
+      # of endpoints rather than a single one).
+      - { name: ENDPOINT_MASK,      value: 0x7F }
+      - { name: BIT_ADDRESS_FLAG,   value: 0x80 }
+    commands:
+      - name: Encap
+        wire:
+          byte: 0x0D
+        decoded_struct:
+          - { name: sourceEndpoint,      type: u8 }
+          - { name: destinationEndpoint, type: u8 }
+          - { name: bitAddress,          type: bool, doc: "destination is a bitmask of endpoints" }
+          - { name: innerCommand,        type: bytes, doc: "encapsulated CC frame (class + cmd + params)" }
+
 
 # =====================================================================
 # 5. Translation rules

--- a/src/zwave-protocol/application/CMakeLists.txt
+++ b/src/zwave-protocol/application/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(zwaved PRIVATE
     ColorSwitch.cpp
     CentralScene.cpp
     SceneActivation.cpp
+    MultiChannel.cpp
     ThermostatMode.cpp
     ThermostatSetpoint.cpp
     ThermostatOperatingState.cpp

--- a/src/zwave-protocol/application/MultiChannel.cpp
+++ b/src/zwave-protocol/application/MultiChannel.cpp
@@ -1,0 +1,46 @@
+#include "MultiChannel.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace
+{
+// CC + cmd + sourceEndpoint + destinationEndpoint, then >= 1 inner byte.
+constexpr std::size_t ENCAP_HEADER_BYTES = 4;
+constexpr std::size_t OFFSET_SOURCE_EP   = 2;
+constexpr std::size_t OFFSET_DEST_EP     = 3;
+constexpr std::size_t OFFSET_INNER       = 4;
+}  // namespace
+
+auto MultiChannel::decodeEncap(std::span<const std::uint8_t> payload) -> std::optional<Encap>
+{
+    // Need the 4-byte header plus at least one inner command byte.
+    if (payload.size() <= ENCAP_HEADER_BYTES || payload[0] != COMMAND_CLASS || payload[1] != MULTI_CHANNEL_ENCAP)
+    {
+        return std::nullopt;
+    }
+    Encap out;
+    out.sourceEndpoint      = static_cast<std::uint8_t>(payload[OFFSET_SOURCE_EP] & ENDPOINT_MASK);
+    out.destinationEndpoint = static_cast<std::uint8_t>(payload[OFFSET_DEST_EP] & ENDPOINT_MASK);
+    out.bitAddress          = (payload[OFFSET_DEST_EP] & BIT_ADDRESS_FLAG) != 0;
+    out.innerCommand.assign(payload.begin() + OFFSET_INNER, payload.end());
+    return out;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): endpoints are clearly named at call sites
+auto MultiChannel::encodeEncap(std::uint8_t sourceEndpoint,
+                               std::uint8_t destinationEndpoint,
+                               std::span<const std::uint8_t> innerCommand) -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> out;
+    out.reserve(ENCAP_HEADER_BYTES + innerCommand.size());
+    out.push_back(COMMAND_CLASS);
+    out.push_back(MULTI_CHANNEL_ENCAP);
+    out.push_back(static_cast<std::uint8_t>(sourceEndpoint & ENDPOINT_MASK));
+    out.push_back(static_cast<std::uint8_t>(destinationEndpoint & ENDPOINT_MASK));
+    out.insert(out.end(), innerCommand.begin(), innerCommand.end());
+    return out;
+}

--- a/src/zwave-protocol/application/MultiChannel.hpp
+++ b/src/zwave-protocol/application/MultiChannel.hpp
@@ -1,0 +1,48 @@
+#ifndef ZWAVED_MULTI_CHANNEL_HPP
+#define ZWAVED_MULTI_CHANNEL_HPP
+
+// IWYU pragma: begin_exports
+#include "MultiChannel.gen.hpp"
+// IWYU pragma: end_exports
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+/// Z-Wave Multi Channel Command Class (0x60) — the encapsulation layer
+/// (E1 Tier 2, #144). A node that presents several addressable endpoints
+/// wraps the real command in MULTI_CHANNEL_CMD_ENCAP, carrying a source and
+/// destination endpoint around the inner CC frame. The daemon decaps inbound
+/// frames (routing them to a logical endpoint, #146) and encaps outbound
+/// endpoint-addressed frames. Only the v2+ ENCAP (0x0D) form is handled.
+/// Constants come from MultiChannel.gen.hpp.
+namespace MultiChannel
+{
+/// Decoded MULTI_CHANNEL_CMD_ENCAP payload. `innerCommand` is the wrapped
+/// CC frame (starting with its own COMMAND_CLASS byte). `bitAddress` is set
+/// when the destination byte's high bit marks a multicast to a bitmask of
+/// endpoints rather than a single endpoint.
+struct Encap
+{
+    std::uint8_t sourceEndpoint      = 0;
+    std::uint8_t destinationEndpoint = 0;
+    bool bitAddress                  = false;
+    std::vector<std::uint8_t> innerCommand;
+};
+
+/// Decode a MULTI_CHANNEL_CMD_ENCAP payload (the bytes inside an
+/// APPLICATION_COMMAND_HANDLER frame, starting with COMMAND_CLASS). Returns
+/// std::nullopt if the bytes are not a well-formed encap (wrong CC/cmd or no
+/// inner command).
+[[nodiscard]] auto decodeEncap(std::span<const std::uint8_t> payload) -> std::optional<Encap>;
+
+/// Encapsulate `innerCommand` (a complete CC frame) for delivery from
+/// `sourceEndpoint` to `destinationEndpoint`. Mirrors decodeEncap.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): endpoints are clearly named at call sites
+[[nodiscard]] auto encodeEncap(std::uint8_t sourceEndpoint,
+                               std::uint8_t destinationEndpoint,
+                               std::span<const std::uint8_t> innerCommand) -> std::vector<std::uint8_t>;
+}  // namespace MultiChannel
+
+#endif  // ZWAVED_MULTI_CHANNEL_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,6 +330,20 @@ target_link_libraries(SceneActivation_test PRIVATE GTest::gtest GTest::gtest_mai
 zwaved_test_target(SceneActivation_test)
 gtest_discover_tests(SceneActivation_test)
 
+# ---- MultiChannel ---------------------------------------------------
+# No .gen.cpp (header-only constants; hand-written encap/decap codec).
+add_executable(MultiChannel_test
+    MultiChannel_test.cpp
+    "${SRC_DIR}/application/MultiChannel.cpp"
+)
+target_include_directories(MultiChannel_test PRIVATE
+    "${SRC_DIR}/application"
+    "${GENERATED_APPLICATION_DIR}"
+)
+target_link_libraries(MultiChannel_test PRIVATE GTest::gtest GTest::gtest_main)
+zwaved_test_target(MultiChannel_test)
+gtest_discover_tests(MultiChannel_test)
+
 # ---- DoorLock -------------------------------------------------------
 add_executable(DoorLock_test
     DoorLock_test.cpp

--- a/tests/MultiChannel_test.cpp
+++ b/tests/MultiChannel_test.cpp
@@ -1,0 +1,69 @@
+#include "MultiChannel.hpp"
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr std::uint8_t CC_MULTI_CHANNEL = 0x60;
+constexpr std::uint8_t CMD_ENCAP        = 0x0D;
+}  // namespace
+
+TEST(MultiChannel, DecodeEncapExtractsEndpointsAndInner)
+{
+    // src endpoint 1, dst endpoint 3, inner = Binary Switch Set ON (0x25 0x01 0xFF).
+    const std::array<std::uint8_t, 7> bytes{CC_MULTI_CHANNEL, CMD_ENCAP, 0x01, 0x03, 0x25, 0x01, 0xFF};
+    const auto decoded = MultiChannel::decodeEncap(std::span<const std::uint8_t>(bytes));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->sourceEndpoint, 1);
+    EXPECT_EQ(decoded->destinationEndpoint, 3);
+    EXPECT_FALSE(decoded->bitAddress);
+    EXPECT_EQ(decoded->innerCommand, (std::vector<std::uint8_t>{0x25, 0x01, 0xFF}));
+}
+
+TEST(MultiChannel, DecodeEncapMasksEndpointBitsAndBitAddress)
+{
+    // dst byte 0x85 = bit-address flag (0x80) | endpoint 5; src byte 0x82 -> endpoint 2.
+    const std::array<std::uint8_t, 6> bytes{CC_MULTI_CHANNEL, CMD_ENCAP, 0x82, 0x85, 0x20, 0x00};
+    const auto decoded = MultiChannel::decodeEncap(std::span<const std::uint8_t>(bytes));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->sourceEndpoint, 2);
+    EXPECT_EQ(decoded->destinationEndpoint, 5);
+    EXPECT_TRUE(decoded->bitAddress);
+    EXPECT_EQ(decoded->innerCommand, (std::vector<std::uint8_t>{0x20, 0x00}));
+}
+
+TEST(MultiChannel, DecodeEncapRejectsMalformed)
+{
+    // No inner command (header only).
+    const std::array<std::uint8_t, 4> noInner{CC_MULTI_CHANNEL, CMD_ENCAP, 0x01, 0x02};
+    EXPECT_FALSE(MultiChannel::decodeEncap(std::span<const std::uint8_t>(noInner)).has_value());
+    // Wrong command class.
+    const std::array<std::uint8_t, 5> wrongCc{0x25, CMD_ENCAP, 0x01, 0x02, 0x25};
+    EXPECT_FALSE(MultiChannel::decodeEncap(std::span<const std::uint8_t>(wrongCc)).has_value());
+    // Wrong command byte.
+    const std::array<std::uint8_t, 5> wrongCmd{CC_MULTI_CHANNEL, 0x0E, 0x01, 0x02, 0x25};
+    EXPECT_FALSE(MultiChannel::decodeEncap(std::span<const std::uint8_t>(wrongCmd)).has_value());
+}
+
+TEST(MultiChannel, EncodeEncapWrapsInner)
+{
+    const std::array<std::uint8_t, 3> inner{0x25, 0x01, 0x00};
+    const auto frame = MultiChannel::encodeEncap(2, 4, std::span<const std::uint8_t>(inner));
+    EXPECT_EQ(frame, (std::vector<std::uint8_t>{CC_MULTI_CHANNEL, CMD_ENCAP, 0x02, 0x04, 0x25, 0x01, 0x00}));
+}
+
+TEST(MultiChannel, EncodeDecodeRoundTrip)
+{
+    const std::array<std::uint8_t, 4> inner{0x26, 0x01, 0x63, 0x00};
+    const auto frame   = MultiChannel::encodeEncap(1, 7, std::span<const std::uint8_t>(inner));
+    const auto decoded = MultiChannel::decodeEncap(std::span<const std::uint8_t>(frame));
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->sourceEndpoint, 1);
+    EXPECT_EQ(decoded->destinationEndpoint, 7);
+    EXPECT_EQ(decoded->innerCommand, (std::vector<std::uint8_t>{0x26, 0x01, 0x63, 0x00}));
+}


### PR DESCRIPTION
Closes #144. Second child of the addressable-presence epic **#142** (E1 Tier 2) — the encapsulation layer that lets one node present several addressable endpoints.

## What
`MULTI_CHANNEL_CMD_ENCAP` (0x0D) wraps an inner CC frame with a source + destination endpoint. New `application/MultiChannel` codec:

- **`decodeEncap`** — extract `(sourceEndpoint, destinationEndpoint, bitAddress, innerCommand)` from an inbound encapsulated frame; masks the endpoint to the low 7 bits and reads the destination byte's bit-address flag. Rejects wrong CC/cmd or a header with no inner command.
- **`encodeEncap`** — wrap an outbound CC frame for an endpoint pair.

v2+ ENCAP only. The manifest module contributes the command byte + `ENDPOINT_MASK` / `BIT_ADDRESS_FLAG` constants; no `.gen.cpp` (dynamic inner payload → hand-written, like CentralScene / SceneActivation).

## Tests / verification
- 5 tests: endpoint extraction, endpoint-bit + bit-address masking, malformed rejection, encode, encode↔decode round-trip.
- Both compilers build clean; **314/314** tests; clang-format + clang-tidy clean.

## Scope note
This is the pure wire codec; daemon wiring (endpoint responder **#145**, inbound routing **#146**) builds on it. The Tier 2 device-compat spike (**#143**) still gates committing to the responder, but the encap format is spec-defined and the codec is useful standalone (e.g. decoding any multi-channel-encapsulated inbound frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)