### PR TITLE
feat: encap-probe observability aid for the E1 Tier 2 spike (#143)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,11 @@ endif()
 set(ZWAVED_LOGGER_SINK "stdout" CACHE STRING "Logger sink (stdout, syslog)")
 set_property(CACHE ZWAVED_LOGGER_SINK PROPERTY STRINGS "stdout" "syslog")
 
+# Temporary spike aids (off by default; remove with their issue). #143:
+# log inbound Multi Channel encapsulated frames so the E1 Tier 2 spike can
+# observe whether a real device addresses a controller endpoint.
+option(ZWAVED_SPIKE_ENCAP_LOG "Spike #143: log inbound Multi Channel encap frames" OFF)
+
 # Process source subdirectories
 add_subdirectory(src)
 

--- a/scripts/e1-tier2-spike/README.md
+++ b/scripts/e1-tier2-spike/README.md
@@ -92,12 +92,28 @@ rather than a clean SQ2 observation.
   park Tier 2.
 - ❌ Device won't encapsulate at all → Tier 2 not viable with this device.
 
-## Optional observability aid
+## Observability aid: the encap probe
 
-If the existing logging isn't enough to spot encap frames, a one-line debug log
-in the cc-translator (`if (auto e = MultiChannel::decodeEncap(ccData)) Logger::info(...)`)
-makes inbound encapsulation visible without building any responder. Add it
-behind a temporary debug flag during the spike; remove before merging anything.
+Build the daemon with the spike probe enabled to log every inbound Multi
+Channel encapsulated frame — no responder needed, read-only:
+
+```bash
+cmake -S . -B cmake-build-gnu -DZWAVED_SPIKE_ENCAP_LOG=ON
+cmake --build cmake-build-gnu --target zwaved
+```
+
+`src/spike/EncapProbe.cpp` then subscribes to the raw `ApplicationCommand` bus
+event and, for any frame that decodes as `MULTI_CHANNEL_CMD_ENCAP` (via #144's
+`decodeEncap`), logs e.g.:
+
+```
+[encap-probe] node=7 src-ep=0 dst-ep=2 inner-len=3 inner-cc=0x25
+```
+
+So during SQ2 you watch the daemon log for an `[encap-probe]` line from the
+device under test with `dst-ep` matching the endpoint you bound. The option is
+**off by default** (excluded from normal builds). Turn it back off — or delete
+`src/spike/` + the `ZWAVED_SPIKE_ENCAP_LOG` option — once the spike concludes.
 
 ## Recording the result
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(zwave-protocol)
 add_subdirectory(cc-translator)
 add_subdirectory(orchestrator)
 add_subdirectory(external-api)
+add_subdirectory(spike)
 
 target_link_libraries(zwaved PRIVATE PkgConfig::LIBUDEV)
 

--- a/src/spike/CMakeLists.txt
+++ b/src/spike/CMakeLists.txt
@@ -1,0 +1,13 @@
+# src/spike/CMakeLists.txt
+# Temporary spike aids, each behind its own off-by-default build option so
+# a normal build excludes them entirely. Remove a probe (file + option)
+# once its spike reaches a conclusion.
+#
+# EncapProbe (#143, E1 Tier 2): logs inbound Multi Channel encapsulated
+# frames so the spike operator can see whether a real device addresses a
+# controller endpoint. Direct source of `zwaved` (not archived) so its
+# __attribute__((constructor)) runs.
+if(ZWAVED_SPIKE_ENCAP_LOG)
+    target_sources(zwaved PRIVATE EncapProbe.cpp)
+    message(STATUS "zwaved: E1 Tier 2 encap-probe ENABLED (spike #143)")
+endif()

--- a/src/spike/EncapProbe.cpp
+++ b/src/spike/EncapProbe.cpp
@@ -1,0 +1,70 @@
+// EncapProbe — E1 Tier 2 spike aid (#143). **Spike-only, off by default.**
+// Compiled into the daemon ONLY when `-DZWAVED_SPIKE_ENCAP_LOG=ON`; a normal
+// build excludes it entirely. It subscribes to the raw inbound
+// `ApplicationCommand` bus event and logs any frame that decodes as a Multi
+// Channel encapsulation (CC 0x60 CMD_ENCAP), so the spike operator can see —
+// directly in the daemon log — whether a real device addresses one of the
+// controller's endpoints. Read-only observability; it never sends anything.
+//
+// Remove (this file + the CMake option) once #143 reaches a go/no-go.
+//
+// It's a direct source of the `zwaved` executable (gated in
+// src/spike/CMakeLists.txt), never archived, so its __attribute__((constructor))
+// self-registration runs — same rule as the orchestrators (#140).
+
+#include "../logger/Logger.hpp"
+#include "../message-bus/MessageBus.hpp"
+#include "../zwave-protocol/application/MultiChannel.hpp"
+#include "../zwaved.h"  // IWYU pragma: keep — CONFIG_ORCHESTRATOR_PRIO
+
+#include <iomanip>
+#include <ios>
+#include <sstream>
+#include <string>
+
+namespace
+{
+// NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public member reads like a struct
+struct State
+{
+    MessageBus::SubscriptionGuard sub;  // auto-unsubscribes on teardown
+
+    State()                                    = default;
+    State(const State&)                        = delete;
+    auto operator=(const State&) -> State&     = delete;
+    State(State&&) noexcept                    = delete;
+    auto operator=(State&&) noexcept -> State& = delete;
+    ~State()                                   = default;
+};
+// NOLINTEND(misc-non-private-member-variables-in-classes)
+
+auto state() -> State&
+{
+    static State instance;
+    return instance;
+}
+
+auto onApplicationCommand(const MessageBus::ApplicationCommand& event) -> void
+{
+    const auto encap = MultiChannel::decodeEncap(event.ccData);
+    if (!encap.has_value())
+    {
+        return;  // not a Multi Channel encapsulated frame — ignore
+    }
+    std::ostringstream stream;
+    stream << "[encap-probe] node=" << static_cast<unsigned>(event.sourceNodeId)
+           << " src-ep=" << static_cast<unsigned>(encap->sourceEndpoint)
+           << " dst-ep=" << static_cast<unsigned>(encap->destinationEndpoint)
+           << (encap->bitAddress ? " (bit-address)" : "") << " inner-len=" << encap->innerCommand.size()
+           << " inner-cc=0x" << std::hex << std::setw(2) << std::setfill('0')
+           << static_cast<unsigned>(encap->innerCommand.empty() ? 0 : encap->innerCommand.front());
+    Logger::info(stream.str());
+}
+
+__attribute__((constructor(CONFIG_ORCHESTRATOR_PRIO))) auto startEncapProbe() -> void
+{
+    state().sub =
+        MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::ApplicationCommand>(onApplicationCommand));
+    Logger::info("[encap-probe] E1 Tier 2 spike build — logging inbound Multi Channel encap frames (#143)");
+}
+}  // namespace


### PR DESCRIPTION
Adds the observability aid for the [#143](https://github.com/Assar63/zwaved/issues/143) spike (E1 Tier 2), as offered.

## What
`src/spike/EncapProbe.cpp` — a **build-time-gated, read-only** probe. It subscribes to the raw `ApplicationCommand` bus event and, for any frame that decodes as `MULTI_CHANNEL_CMD_ENCAP` (#144's `decodeEncap`), logs it:

```
[encap-probe] node=7 src-ep=0 dst-ep=2 inner-len=3 inner-cc=0x25
```

This lets the spike operator watch the daemon log during sub-question SQ2 to see whether a real device sends an encapsulated frame to a controller endpoint — **no responder (#145) needed**.

## Gating
Behind the off-by-default CMake option **`ZWAVED_SPIKE_ENCAP_LOG`** — a normal build excludes it entirely:

```bash
cmake -S . -B cmake-build-gnu -DZWAVED_SPIKE_ENCAP_LOG=ON
```

As a **direct source of the `zwaved` exe** (never archived), its `__attribute__((constructor))` runs — the #140 rule. Spike-only: delete `src/spike/` + the option once #143 concludes.

## Verification
- `-DZWAVED_SPIKE_ENCAP_LOG=ON` compiles clean + clang-tidy clean.
- Default (OFF) build unchanged (probe not compiled).
- `scripts/e1-tier2-spike/README.md` updated to drive the probe via the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)