### PR TITLE
feat: CRC-16 Encapsulation (CC 0x56) — verify + unwrap on receive (#28)

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -3662,6 +3662,24 @@ modules:
           - { name: status,            type: u8 }
           - { name: duration,          type: u8 }
 
+  - name: Crc16Encap
+    wire:
+      class_byte: 0x56
+      prefix: CRC16
+    description: |
+      CRC-16 Encapsulation (#28) — a pre-S0 integrity wrapper. CRC16_ENCAP
+      (0x01) carries an inner CC frame followed by a 2-byte big-endian
+      CRC-16/AUG-CCITT (poly 0x1021, init 0x1D0F) over [CC, cmd, inner].
+      Transport-only: verify-on-receive in practice. No D-Bus surface; the
+      hand-written unwrapper (src/cc-translator/Encapsulation.cpp) verifies
+      the CRC and republishes the inner frame as an ApplicationCommand so
+      the normal decoders fire. verifyAndUnwrap / encode are hand-written in
+      Crc16Encap.cpp; the manifest contributes the command byte.
+    commands:
+      - name: Encap
+        wire:
+          byte: 0x01
+
 
 # =====================================================================
 # 5. Translation rules

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -927,6 +927,16 @@ alongside the raw `ApplicationCommand`. Use the typed signal when you
 only care about that specific CC; use the raw signal when you need to
 handle arbitrary CCs.
 
+**Transport-layer unwrapping.** Some inbound frames arrive wrapped in a
+transport/integrity CC. The daemon verifies/unwraps these transparently and
+re-broadcasts the *inner* CC as a fresh `ApplicationCommand`, so both the raw
+and typed forms above work unchanged — no client-side handling needed:
+
+- **CRC-16 Encapsulation (CC `0x56`, #28)** — a pre-S0 integrity wrapper some
+  legacy non-secure devices still use. The daemon checks the CRC-16/AUG-CCITT
+  trailer and, on success, republishes the inner frame; a frame that fails the
+  CRC is dropped (logged as a warning), never surfaced.
+
 ## 13. Listing nodes
 
 `GetNodes` returns the daemon's in-memory list of currently-included

--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@ Implementation order (each shippable independently):
 
 - [ ] [Security S0 (CC 0x98)](https://github.com/Assar63/zwaved/issues/26)
 - [ ] [Security S2 (CC 0x9F)](https://github.com/Assar63/zwaved/issues/27)
-- [ ] [CRC-16 Encapsulation (CC 0x56)](https://github.com/Assar63/zwaved/issues/28)
+- [x] **CRC-16 Encapsulation (CC `0x56`)** — [#28](https://github.com/Assar63/zwaved/issues/28): transport-only integrity wrapper. `Crc16Encap` codec (CRC-16/AUG-CCITT `checksum` + `verifyAndUnwrap` + `encode`); a hand-written inbound unwrapper (`src/cc-translator/Encapsulation.cpp`) verifies the CRC and republishes the inner frame as an `ApplicationCommand` so the normal decoders fire (bad CRC → dropped + warned). No D-Bus/terminal surface. 6 codec tests. This establishes the inbound-unwrap seam that Transport Service (#25) and the Multi Channel reply-unwrap (#146) plug into.
 
 ### Persistence & configuration
 

--- a/src/cc-translator/CMakeLists.txt
+++ b/src/cc-translator/CMakeLists.txt
@@ -1,9 +1,13 @@
 # src/cc-translator/CMakeLists.txt
 # Bridge module that subscribes to bus ApplicationCommand events,
 # runs the application/ codec decoders, and republishes typed bus
-# events. The body lives entirely in CcTranslator.gen.cpp -- emitted
+# events. The typed-decode body lives in CcTranslator.gen.cpp -- emitted
 # by scripts/codegen/ from the manifest's `cc_translations:` block.
-# This directory holds only the build glue, not source code.
+#
+# Encapsulation.cpp is the hand-written companion: the inbound
+# encapsulation-unwrap layer (CRC-16 #28; Transport Service #25 later)
+# that verifies/reassembles a wrapped frame and republishes the inner CC
+# as an ApplicationCommand, which the generated decoders then handle.
 
 set_source_files_properties(
     "${ZWAVED_GENERATED_DIR}/CcTranslator.gen.cpp"
@@ -12,4 +16,9 @@ set_source_files_properties(
 
 target_sources(zwaved PRIVATE
     "${ZWAVED_GENERATED_DIR}/CcTranslator.gen.cpp"
+    Encapsulation.cpp
 )
+
+# Encapsulation.cpp includes an application/ codec header (Crc16Encap),
+# whose generated constants live under generated/application/.
+target_include_directories(zwaved PRIVATE "${ZWAVED_GENERATED_DIR}/application")

--- a/src/cc-translator/Encapsulation.cpp
+++ b/src/cc-translator/Encapsulation.cpp
@@ -1,0 +1,67 @@
+// Inbound encapsulation-unwrap layer — the hand-written companion to the
+// generated CcTranslator. Some inbound frames arrive wrapped in a
+// transport/integrity CC; this module verifies/unwraps them and republishes
+// the inner CC frame as a fresh ApplicationCommand, so the normal generated
+// decoders (and the D-Bus raw-frame re-emit) handle it transparently —
+// "every downstream decoder works unchanged."
+//
+// Today: CRC-16 Encapsulation (CC 0x56, #28). The inner of a republished
+// frame is never itself a 0x56 wrapper, so the re-entrant publish (under the
+// recursive bus mutex) terminates after one hop. Transport Service (CC 0x55,
+// #25) reassembly will plug in here too.
+
+#include "../logger/Logger.hpp"
+#include "../message-bus/MessageBus.hpp"
+#include "../zwave-protocol/application/Crc16Encap.hpp"
+#include "../zwaved.h"  // IWYU pragma: keep — CONFIG_CC_TRANSLATOR_PRIO
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace
+{
+auto onApplicationCommand(const MessageBus::ApplicationCommand& event) -> void
+{
+    const auto& data = event.ccData;
+    // CRC-16 Encapsulation (CC 0x56, CRC16_ENCAP 0x01).
+    if (data.size() >= 2 && data[0] == Crc16Encap::COMMAND_CLASS && data[1] == Crc16Encap::CRC16_ENCAP)
+    {
+        const auto inner = Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(data));
+        if (!inner.has_value())
+        {
+            Logger::warn("[encapsulation] CRC-16 mismatch from node " + std::to_string(event.sourceNodeId) +
+                         " — dropping frame");
+            return;
+        }
+        MessageBus::publish(MessageBus::ApplicationCommand{.sourceNodeId = event.sourceNodeId, .ccData = *inner});
+    }
+}
+
+// NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public member reads like a struct
+struct State
+{
+    MessageBus::SubscriptionGuard sub;  // auto-unsubscribes on teardown
+
+    State()                                    = default;
+    State(const State&)                        = delete;
+    auto operator=(const State&) -> State&     = delete;
+    State(State&&) noexcept                    = delete;
+    auto operator=(State&&) noexcept -> State& = delete;
+    ~State()                                   = default;
+};
+// NOLINTEND(misc-non-private-member-variables-in-classes)
+
+auto state() -> State&
+{
+    static State instance;
+    return instance;
+}
+
+__attribute__((constructor(CONFIG_CC_TRANSLATOR_PRIO))) auto startEncapsulationUnwrap() -> void
+{
+    state().sub =
+        MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::ApplicationCommand>(onApplicationCommand));
+}
+}  // namespace

--- a/src/zwave-protocol/application/CMakeLists.txt
+++ b/src/zwave-protocol/application/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(zwaved PRIVATE
     MultiChannel.cpp
     Indicator.cpp
     Supervision.cpp
+    Crc16Encap.cpp
     ThermostatMode.cpp
     ThermostatSetpoint.cpp
     ThermostatOperatingState.cpp

--- a/src/zwave-protocol/application/Crc16Encap.cpp
+++ b/src/zwave-protocol/application/Crc16Encap.cpp
@@ -1,0 +1,75 @@
+#include "Crc16Encap.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace
+{
+// CRC-16/AUG-CCITT parameters.
+constexpr std::uint16_t CRC_INIT = 0x1D0F;
+constexpr std::uint16_t CRC_POLY = 0x1021;
+constexpr int BITS_PER_BYTE      = 8;
+constexpr std::uint16_t MSB_MASK = 0x8000;
+
+// CC + cmd + at least one inner byte + 2-byte CRC trailer.
+constexpr std::size_t MIN_BYTES   = 5;
+constexpr std::size_t TRAILER_LEN = 2;
+constexpr std::size_t INNER_START = 2;
+constexpr int BYTE_SHIFT          = 8;
+constexpr std::uint16_t BYTE_MASK = 0x00FF;
+}  // namespace
+
+auto Crc16Encap::checksum(std::span<const std::uint8_t> data) -> std::uint16_t
+{
+    std::uint16_t crc = CRC_INIT;
+    for (const auto byte : data)
+    {
+        crc = static_cast<std::uint16_t>(crc ^ (static_cast<std::uint16_t>(byte) << BITS_PER_BYTE));
+        for (int bit = 0; bit < BITS_PER_BYTE; ++bit)
+        {
+            if ((crc & MSB_MASK) != 0)
+            {
+                crc = static_cast<std::uint16_t>((crc << 1) ^ CRC_POLY);
+            }
+            else
+            {
+                crc = static_cast<std::uint16_t>(crc << 1);
+            }
+        }
+    }
+    return crc;
+}
+
+auto Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t> payload) -> std::optional<std::vector<std::uint8_t>>
+{
+    if (payload.size() < MIN_BYTES || payload[0] != COMMAND_CLASS || payload[1] != CRC16_ENCAP)
+    {
+        return std::nullopt;
+    }
+    const std::size_t bodyLen = payload.size() - TRAILER_LEN;  // everything the CRC covers
+    const auto expected       = checksum(payload.subspan(0, bodyLen));
+    const auto actual = static_cast<std::uint16_t>((static_cast<std::uint16_t>(payload[bodyLen]) << BYTE_SHIFT) |
+                                                   (payload[bodyLen + 1] & BYTE_MASK));
+    if (expected != actual)
+    {
+        return std::nullopt;  // corrupt frame — drop it
+    }
+    const auto inner = payload.subspan(INNER_START, bodyLen - INNER_START);
+    return std::vector<std::uint8_t>(inner.begin(), inner.end());
+}
+
+auto Crc16Encap::encode(std::span<const std::uint8_t> innerCommand) -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> out;
+    out.reserve(INNER_START + innerCommand.size() + TRAILER_LEN);
+    out.push_back(COMMAND_CLASS);
+    out.push_back(CRC16_ENCAP);
+    out.insert(out.end(), innerCommand.begin(), innerCommand.end());
+    const auto crc = checksum(out);
+    out.push_back(static_cast<std::uint8_t>((crc >> BYTE_SHIFT) & BYTE_MASK));
+    out.push_back(static_cast<std::uint8_t>(crc & BYTE_MASK));
+    return out;
+}

--- a/src/zwave-protocol/application/Crc16Encap.hpp
+++ b/src/zwave-protocol/application/Crc16Encap.hpp
@@ -1,0 +1,37 @@
+#ifndef ZWAVED_CRC16_ENCAP_HPP
+#define ZWAVED_CRC16_ENCAP_HPP
+
+// IWYU pragma: begin_exports
+#include "Crc16Encap.gen.hpp"
+// IWYU pragma: end_exports
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+/// Z-Wave CRC-16 Encapsulation Command Class (0x56) — a pre-S0 integrity
+/// wrapper (#28). CRC16_ENCAP (0x01) carries an inner CC frame plus a
+/// trailing 2-byte big-endian CRC-16/AUG-CCITT over the whole command
+/// (CC + cmd + inner). Transport-only: in practice the daemon only
+/// verifies inbound frames and unwraps the inner CC. Constants come from
+/// Crc16Encap.gen.hpp.
+namespace Crc16Encap
+{
+/// CRC-16/AUG-CCITT (poly 0x1021, init 0x1D0F, no reflection, no XOR-out)
+/// over `data`. This is the algorithm CC 0x56 uses — distinct from the
+/// CRC-16-CCITT (init 0xFFFF) used by Transport Service (CC 0x55).
+[[nodiscard]] auto checksum(std::span<const std::uint8_t> data) -> std::uint16_t;
+
+/// Verify a CRC16_ENCAP payload (bytes inside an APPLICATION_COMMAND_HANDLER
+/// frame, starting with COMMAND_CLASS) and return the unwrapped inner CC
+/// frame. Returns std::nullopt if the bytes are not a CRC16_ENCAP, are too
+/// short, or fail the CRC check.
+[[nodiscard]] auto verifyAndUnwrap(std::span<const std::uint8_t> payload) -> std::optional<std::vector<std::uint8_t>>;
+
+/// Wrap `innerCommand` (a complete CC frame) in a CRC16_ENCAP, appending
+/// the computed CRC. Mirrors verifyAndUnwrap.
+[[nodiscard]] auto encode(std::span<const std::uint8_t> innerCommand) -> std::vector<std::uint8_t>;
+}  // namespace Crc16Encap
+
+#endif  // ZWAVED_CRC16_ENCAP_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -344,6 +344,20 @@ target_link_libraries(Indicator_test PRIVATE GTest::gtest GTest::gtest_main)
 zwaved_test_target(Indicator_test)
 gtest_discover_tests(Indicator_test)
 
+# ---- Crc16Encap -----------------------------------------------------
+# No .gen.cpp (header-only constants; hand-written CRC + verify/unwrap).
+add_executable(Crc16Encap_test
+    Crc16Encap_test.cpp
+    "${SRC_DIR}/application/Crc16Encap.cpp"
+)
+target_include_directories(Crc16Encap_test PRIVATE
+    "${SRC_DIR}/application"
+    "${GENERATED_APPLICATION_DIR}"
+)
+target_link_libraries(Crc16Encap_test PRIVATE GTest::gtest GTest::gtest_main)
+zwaved_test_target(Crc16Encap_test)
+gtest_discover_tests(Crc16Encap_test)
+
 # ---- Supervision ----------------------------------------------------
 # No .gen.cpp (header-only constants; hand-written encap + report decode).
 add_executable(Supervision_test

--- a/tests/Crc16Encap_test.cpp
+++ b/tests/Crc16Encap_test.cpp
@@ -1,0 +1,71 @@
+#include "Crc16Encap.hpp"
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr std::uint8_t CC_CRC16  = 0x56;
+constexpr std::uint8_t CMD_ENCAP = 0x01;
+}  // namespace
+
+TEST(Crc16Encap, ChecksumKnownVector)
+{
+    // CRC-16/AUG-CCITT check value for the ASCII string "123456789" is 0xE5CC.
+    const std::array<std::uint8_t, 9> data{'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    EXPECT_EQ(Crc16Encap::checksum(std::span<const std::uint8_t>(data)), 0xE5CC);
+}
+
+TEST(Crc16Encap, EncodeWrapsInnerWithCrc)
+{
+    // inner = Binary Switch SET on (0x25 0x01 0xFF).
+    const std::array<std::uint8_t, 3> inner{0x25, 0x01, 0xFF};
+    const auto frame = Crc16Encap::encode(std::span<const std::uint8_t>(inner));
+    ASSERT_EQ(frame.size(), 7U);  // CC + cmd + 3 inner + 2 CRC
+    EXPECT_EQ(frame[0], CC_CRC16);
+    EXPECT_EQ(frame[1], CMD_ENCAP);
+    // The trailer is the CRC over the first 5 bytes, big-endian.
+    const std::array<std::uint8_t, 5> body{CC_CRC16, CMD_ENCAP, 0x25, 0x01, 0xFF};
+    const auto crc = Crc16Encap::checksum(std::span<const std::uint8_t>(body));
+    EXPECT_EQ(frame[5], static_cast<std::uint8_t>(crc >> 8));
+    EXPECT_EQ(frame[6], static_cast<std::uint8_t>(crc & 0xFF));
+}
+
+TEST(Crc16Encap, EncodeVerifyRoundTrip)
+{
+    const std::array<std::uint8_t, 4> inner{0x31, 0x05, 0x01, 0x2A};
+    const auto frame     = Crc16Encap::encode(std::span<const std::uint8_t>(inner));
+    const auto unwrapped = Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(frame));
+    ASSERT_TRUE(unwrapped.has_value());
+    EXPECT_EQ(*unwrapped, (std::vector<std::uint8_t>{0x31, 0x05, 0x01, 0x2A}));
+}
+
+TEST(Crc16Encap, VerifyRejectsBadCrc)
+{
+    const std::array<std::uint8_t, 3> inner{0x25, 0x01, 0xFF};
+    auto frame = Crc16Encap::encode(std::span<const std::uint8_t>(inner));
+    frame.back() ^= 0xFF;  // corrupt the CRC
+    EXPECT_FALSE(Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(frame)).has_value());
+}
+
+TEST(Crc16Encap, VerifyRejectsCorruptedInner)
+{
+    const std::array<std::uint8_t, 3> inner{0x25, 0x01, 0xFF};
+    auto frame = Crc16Encap::encode(std::span<const std::uint8_t>(inner));
+    frame[2] ^= 0x01;  // flip an inner bit — CRC no longer matches
+    EXPECT_FALSE(Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(frame)).has_value());
+}
+
+TEST(Crc16Encap, VerifyRejectsMalformed)
+{
+    // Wrong command class.
+    const std::array<std::uint8_t, 5> wrongCc{0x25, CMD_ENCAP, 0xFF, 0x00, 0x00};
+    EXPECT_FALSE(Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(wrongCc)).has_value());
+    // Too short (no room for inner + CRC).
+    const std::array<std::uint8_t, 3> tooShort{CC_CRC16, CMD_ENCAP, 0x00};
+    EXPECT_FALSE(Crc16Encap::verifyAndUnwrap(std::span<const std::uint8_t>(tooShort)).has_value());
+}


### PR DESCRIPTION
Closes #28. First of the two transport CCs; establishes the inbound-unwrap seam.

## What
A pre-S0 integrity wrapper — transport-only, no operator-facing surface. Some legacy non-secure devices still send their CCs inside a CRC-16 wrapper.

- **`Crc16Encap` codec**: CRC-16/AUG-CCITT `checksum` (poly 0x1021, init 0x1D0F), `verifyAndUnwrap` (checks CC/cmd + CRC → inner CC frame), `encode` (symmetry/tests). Header-only-gen module.
- **New inbound-unwrap seam** — `src/cc-translator/Encapsulation.cpp`, the hand-written companion to the generated `CcTranslator`. It subscribes to `ApplicationCommand` and, for a CRC-16 frame, verifies and **republishes the inner CC as a fresh `ApplicationCommand`** so the normal decoders + D-Bus raw re-emit handle it unchanged. A frame failing the CRC is dropped with a warning. The re-entrant publish (recursive bus mutex) terminates after one hop.

## Tests / verification
- 6 codec tests: known CRC vector (`0xE5CC` for "123456789"), encode, round-trip, bad-CRC + corrupted-inner rejection, malformed.
- Both compilers build clean; **335/335** tests; clang-format + clang-tidy clean. MANUAL §12 documents the transparent unwrap.

## Why it matters beyond #28
This is the **inbound-unwrap layer** that **#25 (Transport Service** reassembly) and the **Multi Channel reply-unwrap (#146)** will plug into — so #25 is a natural next step on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)