### PR TITLE
feat: Security S0 (CC 0x98) crypto primitives (#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ clang's "not a constant expression" during analysis. Run clang-tidy via
 (the pre-commit hook) only accepts a GCC build dir for this reason, and
 `scripts/bootstrap` sets one up even when `llvm` is the default build.
 
-Requires: GCC 15 (`g++-15`), LLVM/Clang 20 (`clang++-20`), CMake 3.20+, `libudev-dev`, `libsdbus-c++-dev` (pulls in `libsystemd-dev`), `libsqlite3-dev`, eventpp (header-only via `find_package`). C++26 standard.
+Requires: GCC 15 (`g++-15`), LLVM/Clang 20 (`clang++-20`), CMake 3.20+, `libudev-dev`, `libsdbus-c++-dev` (pulls in `libsystemd-dev`), `libsqlite3-dev`, `libssl-dev` (libcrypto, for Security S0 AES), eventpp (header-only via `find_package`). C++26 standard.
 
 `scripts/bootstrap` does one-shot setup (prereq check / apt, `install-hooks`, configure a preset, build once, point `.clangd` at the build dir). Dual-mode: run standalone (downloaded) it clones into a target dir then prepares; run inside a checkout (`./scripts/bootstrap`) it just prepares. Idempotent; `--help` for flags. The manual steps below are the fallback.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUDEV REQUIRED IMPORTED_TARGET libudev)
 pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
 
+# Security S0 (CC 0x98) crypto primitives use AES-128 ECB/OFB/CBC. libcrypto
+# only (no TLS) — in the Ubuntu base + ubiquitous on Yocto/OpenWRT.
+pkg_check_modules(OPENSSL REQUIRED IMPORTED_TARGET libcrypto)
+
 # Header-only event dispatcher / queue. Expected to be provided by the
 # system / cross-sysroot (e.g. Yocto meta-oe recipe, distro package);
 # not vendored in-tree.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A C++ application that manages Z-Wave device communication through a dedicated t
 - **libudev** development files (`libudev-dev`) — USB device monitoring
 - **sdbus-c++** 2.x — D-Bus interface; install from source (the Debian/Ubuntu package is still on 1.x). Requires `libsystemd-dev` for the underlying sd-bus
 - **SQLite3** development files (`libsqlite3-dev`) — node-registry persistence
+- **OpenSSL** development files (`libssl-dev`, provides libcrypto) — Security S0 (CC 0x98) AES-128 primitives
 - **eventpp** (header-only) — in-process publish/subscribe bus; not packaged on most distros, install from source
 - **GoogleTest** development files (`libgtest-dev`) — only needed when `ZWAVED_BUILD_TESTS=ON` (default)
 
@@ -129,7 +130,7 @@ sudo apt install -y g++-15 gcc-15
 sudo apt install -y clang-20 llvm-20
 
 # CMake + runtime libs
-sudo apt install -y cmake libudev-dev libsqlite3-dev libsystemd-dev libgtest-dev
+sudo apt install -y cmake libudev-dev libsqlite3-dev libssl-dev libsystemd-dev libgtest-dev
 
 # sdbus-c++. The Ubuntu/Debian package `libsdbus-c++-dev` ships an older
 # 1.x release; the daemon is built and tested against 2.x. Install from

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,6 +107,7 @@ RUN apt-get update \
         libudev-dev \
         libsdbus-c++-dev \
         libsqlite3-dev \
+        libssl-dev \
         libsystemd-dev \
         libgtest-dev \
         libncurses-dev \

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -116,7 +116,7 @@ readonly PREREQS=(
     "g++-15:g++-15"
     "clang++-20:clang-20"
 )
-readonly DEV_PKGS=(libudev-dev libsdbus-c++-dev libsqlite3-dev libgtest-dev)
+readonly DEV_PKGS=(libudev-dev libsdbus-c++-dev libsqlite3-dev libssl-dev libgtest-dev)
 
 sudo_prefix() {
     if [[ "$(id -u)" -eq 0 ]]; then

--- a/src/zwave-protocol/CMakeLists.txt
+++ b/src/zwave-protocol/CMakeLists.txt
@@ -14,3 +14,4 @@ target_sources(zwaved PRIVATE
 )
 
 add_subdirectory(application)
+add_subdirectory(security)

--- a/src/zwave-protocol/security/CMakeLists.txt
+++ b/src/zwave-protocol/security/CMakeLists.txt
@@ -1,0 +1,5 @@
+# src/zwave-protocol/security/CMakeLists.txt
+# Encrypted-transport command classes. S0 (CC 0x98) today; S2 (CC 0x9F, #27)
+# will sit beside it as a sibling subdirectory.
+
+add_subdirectory(s0)

--- a/src/zwave-protocol/security/s0/CMakeLists.txt
+++ b/src/zwave-protocol/security/s0/CMakeLists.txt
@@ -1,0 +1,11 @@
+# src/zwave-protocol/security/s0/CMakeLists.txt
+# Security S0 (CC 0x98) — encrypted command encapsulation. Phase 1 (#162)
+# lands the crypto primitives; nonce table, network key, and the
+# encapsulation codec follow in later phases of the epic (#26).
+
+target_sources(zwaved PRIVATE
+    Crypto.cpp
+)
+
+# AES-128 ECB/OFB/CBC via OpenSSL libcrypto (no TLS).
+target_link_libraries(zwaved PRIVATE PkgConfig::OPENSSL)

--- a/src/zwave-protocol/security/s0/Crypto.cpp
+++ b/src/zwave-protocol/security/s0/Crypto.cpp
@@ -1,0 +1,113 @@
+#include "Crypto.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include <openssl/evp.h>
+#include <openssl/types.h>
+
+namespace
+{
+// S0 key-derivation passwords: the network key is ECB-encrypted with a block
+// of all-0xAA to get the encryption key, all-0x55 to get the auth key.
+constexpr std::uint8_t KEY_DERIVE_ENC  = 0xAA;
+constexpr std::uint8_t KEY_DERIVE_AUTH = 0x55;
+
+using CipherCtx = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+
+auto makeCtx() -> CipherCtx
+{
+    CipherCtx ctx(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+    if (ctx == nullptr)
+    {
+        throw std::runtime_error("S0::Crypto: EVP_CIPHER_CTX_new failed");
+    }
+    return ctx;
+}
+
+// Encrypt `input` with `cipher` under key/IV, no padding, appending to `out`.
+// Used for ECB (single block), OFB (stream), and CBC (for the MAC).
+auto encryptNoPadding(const EVP_CIPHER* cipher,
+                      const S0::Crypto::Key& key,
+                      const std::uint8_t* initVector,
+                      std::span<const std::uint8_t> input,
+                      std::span<std::uint8_t> out) -> void
+{
+    auto ctx = makeCtx();
+    if (EVP_EncryptInit_ex(ctx.get(), cipher, nullptr, key.data(), initVector) != 1)
+    {
+        throw std::runtime_error("S0::Crypto: EVP_EncryptInit_ex failed");
+    }
+    EVP_CIPHER_CTX_set_padding(ctx.get(), 0);
+    int written = 0;
+    if (EVP_EncryptUpdate(ctx.get(), out.data(), &written, input.data(), static_cast<int>(input.size())) != 1)
+    {
+        throw std::runtime_error("S0::Crypto: EVP_EncryptUpdate failed");
+    }
+    int finalWritten = 0;
+    if (EVP_EncryptFinal_ex(ctx.get(), out.data() + written, &finalWritten) != 1)
+    {
+        throw std::runtime_error("S0::Crypto: EVP_EncryptFinal_ex failed");
+    }
+}
+}  // namespace
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): Key/Block alias the same array type but are distinct roles
+auto S0::Crypto::ecbEncryptBlock(const Key& key, const Block& input) -> Block
+{
+    Block out{};
+    encryptNoPadding(EVP_aes_128_ecb(), key, nullptr, input, out);
+    return out;
+}
+
+auto S0::Crypto::deriveKeys(const Key& networkKey) -> DerivedKeys
+{
+    Block encSeed{};
+    Block authSeed{};
+    encSeed.fill(KEY_DERIVE_ENC);
+    authSeed.fill(KEY_DERIVE_AUTH);
+    const Block enc  = ecbEncryptBlock(networkKey, encSeed);
+    const Block auth = ecbEncryptBlock(networkKey, authSeed);
+
+    DerivedKeys keys{};
+    std::copy(enc.begin(), enc.end(), keys.encryption.begin());
+    std::copy(auth.begin(), auth.end(), keys.authentication.begin());
+    return keys;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): Key/Block alias the same array type but are distinct roles
+auto S0::Crypto::ofbCrypt(const Key& key,
+                          const Block& initVector,
+                          std::span<const std::uint8_t> data) -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> out(data.size());
+    if (!data.empty())
+    {
+        encryptNoPadding(EVP_aes_128_ofb(), key, initVector.data(), data, out);
+    }
+    return out;
+}
+
+auto S0::Crypto::cbcMac(const Key& key, std::span<const std::uint8_t> data) -> Mac
+{
+    // CBC-MAC = the last ciphertext block of a CBC encryption with IV=0 over the
+    // zero-padded message; we keep only its leading MAC_SIZE bytes. An empty
+    // message still MACs over one all-zero block.
+    const std::size_t padded = (data.empty()) ? BLOCK_SIZE : ((data.size() + BLOCK_SIZE - 1) / BLOCK_SIZE) * BLOCK_SIZE;
+    std::vector<std::uint8_t> input(padded, 0);
+    std::copy(data.begin(), data.end(), input.begin());
+
+    std::vector<std::uint8_t> cipher(padded, 0);
+    const Block zeroIv{};
+    encryptNoPadding(EVP_aes_128_cbc(), key, zeroIv.data(), input, cipher);
+
+    Mac mac{};
+    const auto lastBlock = static_cast<std::ptrdiff_t>(padded - BLOCK_SIZE);
+    std::copy(cipher.begin() + lastBlock, cipher.begin() + lastBlock + MAC_SIZE, mac.begin());
+    return mac;
+}

--- a/src/zwave-protocol/security/s0/Crypto.hpp
+++ b/src/zwave-protocol/security/s0/Crypto.hpp
@@ -1,0 +1,60 @@
+#ifndef ZWAVED_S0_CRYPTO_HPP
+#define ZWAVED_S0_CRYPTO_HPP
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+/// Security S0 (CC 0x98) crypto primitives — phase 1 of the S0 epic (#26 / #162).
+///
+/// These are the raw building blocks the rest of the S0 pipeline composes;
+/// frame assembly (authentication-data layout, nonce handling) lives in later
+/// phases. Per SDS10865, S0 uses:
+///   - AES-128-OFB for payload encryption (symmetric — the same call decrypts),
+///   - AES-128 CBC-MAC (raw, IV=0, 8-byte truncated) for authentication,
+///   - AES-128-ECB to derive the encryption key Ke and MAC key Ka from the
+///     single network key (Ke = ECB(K, 0xAA·16), Ka = ECB(K, 0x55·16)).
+///
+/// Implemented over OpenSSL libcrypto, wrapped behind this tight interface so a
+/// future swap to mbedTLS on a constrained target stays a one-file change.
+namespace S0::Crypto
+{
+constexpr std::size_t KEY_SIZE   = 16;  // AES-128
+constexpr std::size_t BLOCK_SIZE = 16;
+constexpr std::size_t MAC_SIZE   = 8;  // S0 truncates the CBC-MAC to 8 bytes
+
+using Key   = std::array<std::uint8_t, KEY_SIZE>;
+using Block = std::array<std::uint8_t, BLOCK_SIZE>;
+using Mac   = std::array<std::uint8_t, MAC_SIZE>;
+
+/// The S0 encryption (Ke) and authentication (Ka) keys derived from the
+/// 16-byte network key.
+struct DerivedKeys
+{
+    Key encryption;
+    Key authentication;
+};
+
+/// Encrypt one 16-byte block with AES-128 in ECB mode. The primitive behind
+/// key derivation; also the per-block step a CBC-MAC reference is built from.
+[[nodiscard]] auto ecbEncryptBlock(const Key& key, const Block& input) -> Block;
+
+/// Derive the S0 Ke / Ka pair from the network key:
+///   Ke = ECB(networkKey, 0xAA·16), Ka = ECB(networkKey, 0x55·16).
+[[nodiscard]] auto deriveKeys(const Key& networkKey) -> DerivedKeys;
+
+/// AES-128-OFB over `data` with the given key and 16-byte IV `initVector` (for
+/// S0 the IV is senderNonce·8 ‖ receiverNonce·8). OFB is symmetric, so this
+/// both encrypts and decrypts; the output is the same length as the input.
+[[nodiscard]] auto ofbCrypt(const Key& key,
+                            const Block& initVector,
+                            std::span<const std::uint8_t> data) -> std::vector<std::uint8_t>;
+
+/// AES-128 CBC-MAC over `data` (zero-padded to a block multiple) with IV=0,
+/// truncated to the leading 8 bytes — the S0 authentication tag.
+[[nodiscard]] auto cbcMac(const Key& key, std::span<const std::uint8_t> data) -> Mac;
+}  // namespace S0::Crypto
+
+#endif  // ZWAVED_S0_CRYPTO_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -358,6 +358,19 @@ target_link_libraries(Crc16Encap_test PRIVATE GTest::gtest GTest::gtest_main)
 zwaved_test_target(Crc16Encap_test)
 gtest_discover_tests(Crc16Encap_test)
 
+# ---- S0 crypto ------------------------------------------------------
+# Security S0 (CC 0x98) phase 1: AES primitives over OpenSSL libcrypto.
+add_executable(s0_crypto_test
+    s0_crypto_test.cpp
+    "${SRC_DIR}/security/s0/Crypto.cpp"
+)
+target_include_directories(s0_crypto_test PRIVATE
+    "${SRC_DIR}/security/s0"
+)
+target_link_libraries(s0_crypto_test PRIVATE GTest::gtest GTest::gtest_main PkgConfig::OPENSSL)
+zwaved_test_target(s0_crypto_test)
+gtest_discover_tests(s0_crypto_test)
+
 # ---- TransportService -----------------------------------------------
 # No .gen.cpp (header-only constants; hand-written split + reassembler + FCS).
 add_executable(TransportService_test

--- a/tests/s0_crypto_test.cpp
+++ b/tests/s0_crypto_test.cpp
@@ -1,0 +1,128 @@
+#include "Crypto.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Authoritative known-answer vectors for the raw AES primitives come from
+// FIPS-197 (ECB) and NIST SP800-38A (OFB). The S0-specific pieces
+// (key derivation, CBC-MAC) are cross-checked against the FIPS-validated
+// block cipher — SDS10865 doesn't publish byte vectors we can cite verbatim.
+
+namespace
+{
+using S0::Crypto::Block;
+using S0::Crypto::Key;
+
+// FIPS-197 Appendix C.1 — AES-128 single-block encryption.
+constexpr Key FIPS_KEY{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+constexpr Block FIPS_IN{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+constexpr Block FIPS_OUT{
+    0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30, 0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4, 0xc5, 0x5a};
+
+// NIST SP800-38A F.4 — OFB-AES128.
+constexpr Key OFB_KEY{0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
+constexpr Block OFB_IV{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+constexpr std::array<std::uint8_t, 64> OFB_PLAINTEXT{
+    0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a,
+    0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03, 0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51,
+    0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1, 0x19, 0x1a, 0x0a, 0x52, 0xef,
+    0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b, 0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10};
+constexpr std::array<std::uint8_t, 64> OFB_CIPHERTEXT{
+    0x3b, 0x3f, 0xd9, 0x2e, 0xb7, 0x2d, 0xad, 0x20, 0x33, 0x34, 0x49, 0xf8, 0xe8, 0x3c, 0xfb, 0x4a,
+    0x77, 0x89, 0x50, 0x8d, 0x16, 0x91, 0x8f, 0x03, 0xf5, 0x3c, 0x52, 0xda, 0xc5, 0x4e, 0xd8, 0x25,
+    0x97, 0x40, 0x05, 0x1e, 0x9c, 0x5f, 0xec, 0xf6, 0x43, 0x44, 0xf7, 0xa8, 0x22, 0x60, 0xed, 0xcc,
+    0x30, 0x4c, 0x65, 0x28, 0xf6, 0x59, 0xc7, 0x78, 0x66, 0xa5, 0x10, 0xd9, 0xc1, 0xd6, 0xae, 0x5e};
+
+// Reference CBC-MAC built from the FIPS-validated single-block primitive, to
+// independently confirm S0::Crypto::cbcMac.
+auto referenceCbcMac(const Key& key, std::span<const std::uint8_t> data) -> std::array<std::uint8_t, 8>
+{
+    constexpr std::size_t blockSize = 16;
+    Block state{};
+    const std::size_t padded = data.empty() ? blockSize : ((data.size() + blockSize - 1) / blockSize) * blockSize;
+    for (std::size_t off = 0; off < padded; off += blockSize)
+    {
+        Block blk{};
+        for (std::size_t i = 0; i < blockSize && off + i < data.size(); ++i)
+        {
+            blk[i] = data[off + i];
+        }
+        for (std::size_t i = 0; i < blockSize; ++i)
+        {
+            blk[i] ^= state[i];
+        }
+        state = S0::Crypto::ecbEncryptBlock(key, blk);
+    }
+    std::array<std::uint8_t, 8> mac{};
+    std::copy(state.begin(), state.begin() + 8, mac.begin());
+    return mac;
+}
+}  // namespace
+
+TEST(S0Crypto, EcbEncryptBlockMatchesFips197)
+{
+    EXPECT_EQ(S0::Crypto::ecbEncryptBlock(FIPS_KEY, FIPS_IN), FIPS_OUT);
+}
+
+TEST(S0Crypto, OfbMatchesNistSp800_38a)
+{
+    const auto out = S0::Crypto::ofbCrypt(OFB_KEY, OFB_IV, std::span<const std::uint8_t>(OFB_PLAINTEXT));
+    EXPECT_EQ(out, std::vector<std::uint8_t>(OFB_CIPHERTEXT.begin(), OFB_CIPHERTEXT.end()));
+}
+
+TEST(S0Crypto, OfbIsSymmetric)
+{
+    // Feeding the ciphertext back through the same call recovers the plaintext.
+    const auto recovered = S0::Crypto::ofbCrypt(OFB_KEY, OFB_IV, std::span<const std::uint8_t>(OFB_CIPHERTEXT));
+    EXPECT_EQ(recovered, std::vector<std::uint8_t>(OFB_PLAINTEXT.begin(), OFB_PLAINTEXT.end()));
+}
+
+TEST(S0Crypto, CbcMacSingleBlockEqualsEcbPrefix)
+{
+    // For a one-block message with IV=0, CBC-MAC = the leading 8 bytes of
+    // ECB(key, block) — pinned to the FIPS-197 known answer.
+    const auto mac = S0::Crypto::cbcMac(FIPS_KEY, std::span<const std::uint8_t>(FIPS_IN));
+    EXPECT_TRUE(std::equal(mac.begin(), mac.end(), FIPS_OUT.begin()));
+}
+
+TEST(S0Crypto, CbcMacMultiBlockMatchesReferenceChain)
+{
+    // 37 bytes — deliberately not a block multiple, to exercise zero-padding.
+    std::vector<std::uint8_t> data(37);
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<std::uint8_t>(i * 7 + 1);
+    }
+    const auto mac = S0::Crypto::cbcMac(FIPS_KEY, std::span<const std::uint8_t>(data));
+    const auto ref = referenceCbcMac(FIPS_KEY, std::span<const std::uint8_t>(data));
+    EXPECT_EQ(mac, ref);
+}
+
+TEST(S0Crypto, DeriveKeysUsesEcbWithS0Constants)
+{
+    const auto keys = S0::Crypto::deriveKeys(FIPS_KEY);
+    Block encSeed{};
+    Block authSeed{};
+    encSeed.fill(0xAA);
+    authSeed.fill(0x55);
+    EXPECT_EQ(keys.encryption, S0::Crypto::ecbEncryptBlock(FIPS_KEY, encSeed));
+    EXPECT_EQ(keys.authentication, S0::Crypto::ecbEncryptBlock(FIPS_KEY, authSeed));
+    // Ke and Ka must differ — the two derivation constants are distinct.
+    EXPECT_NE(keys.encryption, keys.authentication);
+}
+
+TEST(S0Crypto, EncryptDecryptRoundTripWithDerivedKey)
+{
+    const auto keys = S0::Crypto::deriveKeys(FIPS_KEY);
+    const std::vector<std::uint8_t> payload{0x98, 0x81, 0x25, 0x01, 0xFF, 0x00, 0x42};
+    const auto cipher = S0::Crypto::ofbCrypt(keys.encryption, OFB_IV, std::span<const std::uint8_t>(payload));
+    EXPECT_NE(cipher, payload);
+    const auto plain = S0::Crypto::ofbCrypt(keys.encryption, OFB_IV, std::span<const std::uint8_t>(cipher));
+    EXPECT_EQ(plain, payload);
+}


### PR DESCRIPTION
Closes #162. **Phase 1** of the Security S0 epic (#26) — the raw AES-128 building blocks the rest of the S0 pipeline composes. No daemon wiring yet (that's phases 3–6); this lands the foundation + its test vectors.

## What's here
- **`src/zwave-protocol/security/s0/Crypto.{hpp,cpp}`** — `namespace S0::Crypto`:
  - `ecbEncryptBlock` — AES-128-ECB single block (key-derivation primitive)
  - `deriveKeys` — `Ke = ECB(K, 0xAA·16)`, `Ka = ECB(K, 0x55·16)`
  - `ofbCrypt` — AES-128-OFB (symmetric: encrypts *and* decrypts)
  - `cbcMac` — AES-128 CBC-MAC (IV=0, zero-padded, 8-byte truncated)
  - over OpenSSL **libcrypto** (no TLS), behind a tight interface so a future mbedTLS swap on a constrained target stays a one-file change.
- **`tests/s0_crypto_test.cpp`** — 7 tests. The raw primitives are pinned to authoritative **FIPS-197** (ECB) and **NIST SP800-38A** (OFB) known-answer vectors; key derivation + CBC-MAC are cross-checked against the FIPS-validated block cipher. (SDS10865 doesn't publish byte vectors to cite verbatim — noted in a comment.)
- **CMake** — `pkg_check_modules(OPENSSL REQUIRED IMPORTED_TARGET libcrypto)` + `security/{,s0/}CMakeLists.txt` (sibling slot ready for S2, #27).
- **`libssl-dev`** added to `docker/Dockerfile`, `scripts/bootstrap`, `CLAUDE.md`, `README.md`.

## Crypto note
The epic originally said "CBC/CMAC"; S0 is actually **OFB + CBC-MAC + ECB-derivation** per SDS10865 — corrected in #26/#162 and reflected here.

## Verification
Host lacks `libcrypto`, so verified through the exact `docker build` CI runs:
- **`build` (gnu)** and **`build-llvm` (clang-20)** stages — both **349/349 ctest pass** (342 + 7 new).
- **clang-tidy** + **clang-format** run in-image — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)