### PR TITLE
feat: Security S2 (CC 0x9F) multi-class network-key storage (#180)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,13 @@ Each component owns its thread and `running` flag inside an anonymous namespace,
 
 - **Outbound encrypt-on-send** (#175) — `ProtocolThread::pushSendData` diverts any non-`0x98` payload bound for a secure node (`NodeRegistry::isSecure`) into a `SecureSendRequest`; `src/orchestrator/SecurityOutboundOrchestrator.cpp` runs the `NONCE_GET → NONCE_REPORT → encrypt` dance and emits the wrapper back as a `SendDataCommand` (a `0x98` frame, so `pushSendData` sends it raw — no loop). Sends are serialised one-nonce-per-message (OFB keystream must not repeat).
 
-Remaining: **on-bench acceptance** (#168) — the whole S0 wire path is still pending end-to-end verification on a real device. The directory is a sibling slot for S2 (CC `0x9F`, #27).
+Remaining: **on-bench acceptance** (#168) — the whole S0 wire path is still pending end-to-end verification on a real device.
+
+`src/zwave-protocol/security/s2/` is the in-progress Security S2 (CC `0x9F`) stack (epic #27) — the daemon's largest, building beside `s0/`. Like S0 it's **OpenSSL `libcrypto` only** (no libsodium: it lacks AES-128/CCM/CMAC, and libcrypto does X25519). Built incrementally:
+- `Crypto.{hpp,cpp}` (#179) — `namespace S2::Crypto`: AES-128-CCM (`ccmEncrypt`/`ccmDecrypt`), AES-128-CMAC (`cmac`, via `EVP_MAC`), and Curve25519 ECDH (`generateKeyPair`/`ecdh`, via `EVP_PKEY_X25519`), behind a tight interface; KATs pinned to NIST SP800-38C/38B + RFC 7748.
+- `NetworkKeys.{hpp,cpp}` (#180) — the four per-class 16-byte keys (Unauthenticated / Authenticated / Access Control / S0-compat), load-or-generate at `[security] s2_key_dir` (default `<state_dir>/security/s2/`, each file `0600`). Constructor-armed `NetworkKeysService.cpp` (priority `CONFIG_SECURITY_PRIO`) resolves the dir from `SecurityConfig` + `StorageConfig`, loads/generates at startup, sets the in-process `current()` set, and publishes retained `S2NetworkKeysReady` (failure → `DaemonError CODE_S2_KEYS_FAILED`, degrades to "S2 unavailable").
+
+Remaining S2 phases — SPAN nonce protocol, encapsulation codec, KEX handshake, public-key/DSK exchange, key install, ProtocolThread integration, inclusion wiring, MPAN — are children of #27 (#181–#189).
 
 `src/external-api/` exposes the host API to clients. The transport-agnostic interface is `ExternalApi::IBackend` declared in `IExternalApi.hpp`, plus a `createBackend()` factory; `DBusBackend` is the only implementation today (system bus, name `com.tiunda.ZWaved`, object `/com/tiunda/ZWaved`, interface `com.tiunda.ZWaved1`). The system-bus policy XML is at `dbus/com.tiunda.ZWaved.conf` and must be installed under `/etc/dbus-1/system.d/` for non-root callers. Operator usage (classic vs SmartStart inclusion, signal payload layout, status table, troubleshooting) is in `MANUAL.md`.
 

--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -165,6 +165,18 @@ events:
       - { name: ready,     type: bool, default: false }
       - { name: generated, type: bool, default: false }
 
+  - name: S2NetworkKeysReady
+    category: state
+    direction: { publishers: [zwave-protocol], subscribers: [orchestrator] }
+    doc: |
+      Security S2 (CC 0x9F) multi-class key lifecycle (#180). Published once the
+      four per-class keys have been loaded or generated, so the S2 inclusion /
+      transport phases can defer until keys exist. `generated` is true if any
+      class key was freshly created on this run. Retained.
+    fields:
+      - { name: ready,     type: bool, default: false }
+      - { name: generated, type: bool, default: false }
+
   - name: NodeSecurityStatus
     category: state
     direction: { publishers: [cc-translator, orchestrator], subscribers: [external-api] }
@@ -213,6 +225,7 @@ events:
       - { name: CODE_DONGLE_OPEN_FAILED,          value: 0x10, doc: "serial port open() / configure failed" }
       - { name: CODE_DONGLE_INTROSPECTION_FAILED, value: 0x11, doc: "GET_VERSION or MEMORY_GET_ID didn't answer" }
       - { name: CODE_S0_KEY_FAILED,               value: 0x12, doc: "S0 network key couldn't be loaded or generated" }
+      - { name: CODE_S2_KEYS_FAILED,              value: 0x13, doc: "S2 network keys couldn't be loaded or generated" }
       - { name: CODE_UDEV_INIT_FAILED,            value: 0x20, doc: "libudev context or monitor creation failed" }
       - { name: CODE_DBUS_BIND_FAILED,            value: 0x30, doc: "couldn't acquire the system-bus name" }
       - { name: CODE_EXTERNAL_API_NO_BACKEND,     value: 0x31, doc: "no external-API backend compiled in" }
@@ -288,10 +301,11 @@ events:
     direction: { publishers: [config], subscribers: [zwave-protocol] }
     doc: |
       Security key-file locations. An empty s0KeyFile means fall back to
-      <stateDir>/security/s0.key (StorageConfig). S2 (#27) will extend this
-      event with its multiple key files.
+      <stateDir>/security/s0.key; an empty s2KeyDir means fall back to
+      <stateDir>/security/s2/ (the four per-class S2 keys live there).
     fields:
       - { name: s0KeyFile, type: string }
+      - { name: s2KeyDir,  type: string }
 
   # ---- 2c. Transient protocol events ------------------------------
 

--- a/etc/zwaved.conf
+++ b/etc/zwaved.conf
@@ -36,6 +36,13 @@ state_dir = /var/lib/zwaved
 # Back it up. By default it lives under state_dir; set an explicit path
 # here to place it elsewhere (e.g. a dedicated keys directory).
 # s0_key_file = /etc/zwaved/keys/s0.key
+#
+# Security S2 (CC 0x9F) keys. S2 holds four 16-byte per-class keys
+# (unauth / auth / access / s0compat). They live as separate 0600 files
+# in this directory. Resolution order: this key first, then
+# <state_dir>/security/s2/. Same back-up warning as the S0 key — losing
+# them forces re-inclusion (with DSK confirmation) of every secure node.
+# s2_key_dir = /etc/zwaved/keys/s2
 
 [dongles]
 # USB dongles the monitor thread will accept. Format per row:

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -236,6 +236,10 @@ auto loadSecuritySection(const ParsedFile& file, MessageBus::SecurityConfig& sec
     {
         security.s0KeyFile = *value;
     }
+    if (const auto value = firstValue(file, "security", "s2_key_dir"); value.has_value())
+    {
+        security.s2KeyDir = *value;
+    }
 }
 
 auto loadDonglesSection(const ParsedFile& file, MessageBus::DonglesConfig& dongles) -> void

--- a/src/zwave-protocol/security/s2/CMakeLists.txt
+++ b/src/zwave-protocol/security/s2/CMakeLists.txt
@@ -5,6 +5,11 @@
 
 target_sources(zwaved PRIVATE
     Crypto.cpp
+    NetworkKeys.cpp
+    # Constructor-armed (CONFIG_SECURITY_PRIO) — must be a direct zwaved
+    # source, never a passively-linked archive member, or its .init_array
+    # entry is dropped and the keys are never loaded.
+    NetworkKeysService.cpp
 )
 
 # AES-128-CCM + CMAC + Curve25519 ECDH, all via OpenSSL libcrypto (no TLS,

--- a/src/zwave-protocol/security/s2/NetworkKeys.cpp
+++ b/src/zwave-protocol/security/s2/NetworkKeys.cpp
@@ -1,0 +1,176 @@
+#include "NetworkKeys.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+
+#include <fcntl.h>
+#include <openssl/rand.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace
+{
+constexpr const char* DEFAULT_STATE_DIR = "/var/lib/zwaved";
+constexpr const char* STATE_DIR_ENV     = "ZWAVED_STATE_DIR";
+constexpr int KEY_FILE_MODE             = 0600;  // owner read/write only
+
+// Read exactly one key from `path`; false on open / short / long read.
+auto readKey(const std::filesystem::path& path, S2::Crypto::Key& out) -> bool
+{
+    std::error_code errc;
+    if (std::filesystem::file_size(path, errc) != out.size() || errc)
+    {
+        return false;
+    }
+    const int keyFd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);  // NOLINT(cppcoreguidelines-pro-type-vararg)
+    if (keyFd < 0)
+    {
+        return false;
+    }
+    const ssize_t got = ::read(keyFd, out.data(), out.size());
+    ::close(keyFd);
+    return got == static_cast<ssize_t>(out.size());
+}
+
+// Create `path` exclusively (0600) and write `key`; false if it already exists
+// (lost a race) or on any I/O error.
+auto writeKeyExclusive(const std::filesystem::path& path, const S2::Crypto::Key& key) -> bool
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): open()'s mode arg is the documented variadic
+    const int keyFd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, KEY_FILE_MODE);
+    if (keyFd < 0)
+    {
+        return false;
+    }
+    const ssize_t put = ::write(keyFd, key.data(), key.size());
+    ::close(keyFd);
+    if (put != static_cast<ssize_t>(key.size()))
+    {
+        std::error_code errc;
+        std::filesystem::remove(path, errc);
+        return false;
+    }
+    return true;
+}
+
+// Load one key at `path`, or generate + persist it. Returns the key and whether
+// it was freshly created; std::nullopt on any I/O / RNG failure.
+struct OneKey
+{
+    S2::Crypto::Key key{};
+    bool generated = false;
+};
+auto loadOrGenerateOne(const std::filesystem::path& path) -> std::optional<OneKey>
+{
+    OneKey result;
+    if (readKey(path, result.key))
+    {
+        return result;
+    }
+    if (RAND_bytes(result.key.data(), static_cast<int>(result.key.size())) != 1)
+    {
+        return std::nullopt;
+    }
+    if (!writeKeyExclusive(path, result.key))
+    {
+        // Lost a create race — re-read whatever is now there.
+        if (readKey(path, result.key))
+        {
+            return result;
+        }
+        return std::nullopt;
+    }
+    result.generated = true;
+    return result;
+}
+}  // namespace
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): s2KeyDir-then-stateDir matches the config field order
+auto S2::NetworkKeys::resolveDir(const std::string& s2KeyDir, const std::string& stateDir) -> std::filesystem::path
+{
+    if (!s2KeyDir.empty())
+    {
+        return s2KeyDir;
+    }
+    std::string dir = stateDir;
+    if (dir.empty())
+    {
+        // NOLINTNEXTLINE(concurrency-mt-unsafe): runs during single-threaded startup
+        if (const char* env = std::getenv(STATE_DIR_ENV); env != nullptr && *env != '\0')
+        {
+            dir = env;
+        }
+        else
+        {
+            dir = DEFAULT_STATE_DIR;
+        }
+    }
+    return std::filesystem::path(dir) / "security" / "s2";
+}
+
+auto S2::NetworkKeys::fileName(Class cls) -> std::string
+{
+    switch (cls)
+    {
+    case Class::Unauthenticated:
+        return "unauth.key";
+    case Class::Authenticated:
+        return "auth.key";
+    case Class::AccessControl:
+        return "access.key";
+    case Class::S0Compat:
+        return "s0compat.key";
+    }
+    return "unknown.key";
+}
+
+auto S2::NetworkKeys::loadOrGenerateAll(const std::filesystem::path& dir) -> std::optional<Loaded>
+{
+    std::error_code errc;
+    std::filesystem::create_directories(dir, errc);
+    if (errc)
+    {
+        return std::nullopt;
+    }
+    Loaded loaded;
+    for (std::size_t i = 0; i < CLASS_COUNT; ++i)
+    {
+        const auto one = loadOrGenerateOne(dir / fileName(static_cast<Class>(i)));
+        if (!one.has_value())
+        {
+            return std::nullopt;
+        }
+        loaded.keys.at(i)      = one->key;
+        loaded.generated.at(i) = one->generated;
+    }
+    return loaded;
+}
+
+auto S2::NetworkKeys::keyFor(const KeySet& keys, Class cls) -> const Crypto::Key&
+{
+    return keys.at(static_cast<std::size_t>(cls));
+}
+
+namespace
+{
+auto keySlot() -> std::optional<S2::NetworkKeys::KeySet>&
+{
+    static std::optional<S2::NetworkKeys::KeySet> slot;
+    return slot;
+}
+}  // namespace
+
+auto S2::NetworkKeys::current() -> std::optional<KeySet>
+{
+    return keySlot();
+}
+
+auto S2::NetworkKeys::setCurrent(const KeySet& keys) -> void
+{
+    keySlot() = keys;
+}

--- a/src/zwave-protocol/security/s2/NetworkKeys.hpp
+++ b/src/zwave-protocol/security/s2/NetworkKeys.hpp
@@ -1,0 +1,64 @@
+#ifndef ZWAVED_S2_NETWORK_KEYS_HPP
+#define ZWAVED_S2_NETWORK_KEYS_HPP
+
+// IWYU pragma: begin_exports
+#include "Crypto.hpp"  // S2::Crypto::Key
+// IWYU pragma: end_exports
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+/// Security S2 (CC 0x9F) multi-class network-key persistence — phase 2 of the
+/// S2 epic (#27 / #180). S2 holds one 16-byte key per security class; the
+/// inclusion handshake grants a node a subset of classes, and the
+/// decapsulator picks the matching key from a frame's class byte.
+namespace S2::NetworkKeys
+{
+/// The S2 key classes, in their canonical order (also the KeySet index).
+enum class Class : std::uint8_t
+{
+    Unauthenticated = 0,  ///< included without DSK confirmation
+    Authenticated   = 1,  ///< DSK confirmed at inclusion
+    AccessControl   = 2,  ///< locks; strongest pairing
+    S0Compat        = 3,  ///< S0 traffic bridged into an S2 network
+};
+constexpr std::size_t CLASS_COUNT = 4;
+
+using KeySet = std::array<Crypto::Key, CLASS_COUNT>;
+
+struct Loaded
+{
+    KeySet keys{};
+    std::array<bool, CLASS_COUNT> generated{};  ///< per-class: freshly created this run
+};
+
+/// The key directory: `s2KeyDir` verbatim when non-empty, else
+/// `<stateDir>/security/s2` (with `stateDir` falling back to
+/// $ZWAVED_STATE_DIR then the built-in default).
+[[nodiscard]] auto resolveDir(const std::string& s2KeyDir, const std::string& stateDir) -> std::filesystem::path;
+
+/// File name for a class's key within the directory (e.g. `auth.key`).
+[[nodiscard]] auto fileName(Class cls) -> std::string;
+
+/// Load every class key from `dir`, generating + persisting (mode `0600`,
+/// `O_CREAT | O_EXCL`) any that are absent. Returns std::nullopt if any class
+/// can't be loaded or generated — S2 needs all four, so it's all-or-nothing.
+[[nodiscard]] auto loadOrGenerateAll(const std::filesystem::path& dir) -> std::optional<Loaded>;
+
+/// Index a KeySet by class.
+[[nodiscard]] auto keyFor(const KeySet& keys, Class cls) -> const Crypto::Key&;
+
+/// The in-process key set, once `NetworkKeysService` has loaded/generated it at
+/// startup; std::nullopt while S2 is unavailable. Set once during the
+/// priority-111 constructor (before any worker thread), read on the bus thread.
+[[nodiscard]] auto current() -> std::optional<KeySet>;
+
+/// Publish the loaded key set as the process-wide current set.
+auto setCurrent(const KeySet& keys) -> void;
+}  // namespace S2::NetworkKeys
+
+#endif  // ZWAVED_S2_NETWORK_KEYS_HPP

--- a/src/zwave-protocol/security/s2/NetworkKeysService.cpp
+++ b/src/zwave-protocol/security/s2/NetworkKeysService.cpp
@@ -1,0 +1,89 @@
+// Constructor-armed bus wiring for the Security S2 network keys (#180) — the
+// thin companion to the pure load-or-generate core in NetworkKeys.cpp. At
+// startup it resolves the key directory from the retained SecurityConfig +
+// StorageConfig events, loads or generates the four per-class keys, and
+// publishes the retained S2NetworkKeysReady event so the later S2 phases can
+// defer secure work until the keys exist. A load failure is logged + surfaced
+// on the DaemonError feed; S2 is then unavailable but the daemon still runs.
+
+#include "../../../logger/Logger.hpp"
+#include "../../../message-bus/MessageBus.hpp"
+#include "../../../zwaved.h"  // IWYU pragma: keep — CONFIG_SECURITY_PRIO
+#include "NetworkKeys.hpp"
+
+#include <optional>
+#include <string>
+
+namespace
+{
+// NOLINTBEGIN(misc-non-private-member-variables-in-classes): file-local singleton, public members read like a struct
+struct State
+{
+    MessageBus::SubscriptionGuard storageSub;
+    MessageBus::SubscriptionGuard securitySub;
+    std::string stateDir;
+    std::string s2KeyDir;
+
+    State()                                    = default;
+    State(const State&)                        = delete;
+    auto operator=(const State&) -> State&     = delete;
+    State(State&&) noexcept                    = delete;
+    auto operator=(State&&) noexcept -> State& = delete;
+    ~State()                                   = default;
+};
+// NOLINTEND(misc-non-private-member-variables-in-classes)
+
+auto state() -> State&
+{
+    static State instance;
+    return instance;
+}
+
+auto loadKeys() -> void
+{
+    const auto dir    = S2::NetworkKeys::resolveDir(state().s2KeyDir, state().stateDir);
+    const auto loaded = S2::NetworkKeys::loadOrGenerateAll(dir);
+    if (!loaded.has_value())
+    {
+        Logger::error("[s2] could not load or generate the network keys in " + dir.string() +
+                      " — S2 secure operations unavailable");
+        MessageBus::publish(MessageBus::DaemonError{
+            .severity = MessageBus::DaemonError::SEVERITY_ERROR,
+            .source   = "zwave-protocol",
+            .code     = MessageBus::DaemonError::CODE_S2_KEYS_FAILED,
+            .message  = "S2 network keys unavailable in " + dir.string(),
+        });
+        return;
+    }
+
+    S2::NetworkKeys::setCurrent(loaded->keys);
+    bool anyGenerated = false;
+    for (const bool gen : loaded->generated)
+    {
+        anyGenerated = anyGenerated || gen;
+    }
+    if (anyGenerated)
+    {
+        // Audit trail: key generation is security-significant.
+        Logger::warn("[s2] generated one or more network keys in " + dir.string() +
+                     " — back them up; losing them forces re-inclusion (with DSK) of every secure node");
+    }
+    else
+    {
+        Logger::info("[s2] loaded the network keys from " + dir.string());
+    }
+    MessageBus::publish(MessageBus::S2NetworkKeysReady{.ready = true, .generated = anyGenerated});
+}
+
+__attribute__((constructor(CONFIG_SECURITY_PRIO))) auto startNetworkKeysService() -> void
+{
+    // Both config events are retained and already published by priority 102, so
+    // each subscribe replays synchronously and the cached values are in place
+    // before loadKeys() resolves the directory.
+    state().storageSub  = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::StorageConfig>(
+        [](const MessageBus::StorageConfig& cfg) -> void { state().stateDir = cfg.stateDir; }));
+    state().securitySub = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::SecurityConfig>(
+        [](const MessageBus::SecurityConfig& cfg) -> void { state().s2KeyDir = cfg.s2KeyDir; }));
+    loadKeys();
+}
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -371,6 +371,20 @@ target_link_libraries(s2_crypto_test PRIVATE GTest::gtest GTest::gtest_main PkgC
 zwaved_test_target(s2_crypto_test)
 gtest_discover_tests(s2_crypto_test)
 
+# ---- S2 network keys ------------------------------------------------
+# Security S2 (CC 0x9F) phase 2: multi-class key load-or-generate. Pure core
+# (no bus); links libcrypto for RAND_bytes.
+add_executable(s2_network_keys_test
+    s2_network_keys_test.cpp
+    "${SRC_DIR}/security/s2/NetworkKeys.cpp"
+)
+target_include_directories(s2_network_keys_test PRIVATE
+    "${SRC_DIR}/security/s2"
+)
+target_link_libraries(s2_network_keys_test PRIVATE GTest::gtest GTest::gtest_main PkgConfig::OPENSSL)
+zwaved_test_target(s2_network_keys_test)
+gtest_discover_tests(s2_network_keys_test)
+
 # ---- S0 crypto ------------------------------------------------------
 # Security S0 (CC 0x98) phase 1: AES primitives over OpenSSL libcrypto.
 add_executable(s0_crypto_test

--- a/tests/s2_network_keys_test.cpp
+++ b/tests/s2_network_keys_test.cpp
@@ -1,0 +1,95 @@
+// Security S2 (CC 0x9F) multi-class network-key persistence (#180).
+
+#include "NetworkKeys.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <set>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+namespace fs = std::filesystem;
+using S2::NetworkKeys::Class;
+
+class S2NetworkKeysTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        dir_ = fs::temp_directory_path() / ("zwaved_s2keys_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        fs::create_directories(dir_);
+    }
+    void TearDown() override
+    {
+        std::error_code errc;
+        fs::remove_all(dir_, errc);
+    }
+    fs::path dir_;
+};
+}  // namespace
+
+TEST_F(S2NetworkKeysTest, GeneratesAllFourOnFirstUse)
+{
+    const auto loaded = S2::NetworkKeys::loadOrGenerateAll(dir_);
+    ASSERT_TRUE(loaded.has_value());
+    for (std::size_t i = 0; i < S2::NetworkKeys::CLASS_COUNT; ++i)
+    {
+        EXPECT_TRUE(loaded->generated.at(i));
+        const auto path = dir_ / S2::NetworkKeys::fileName(static_cast<Class>(i));
+        EXPECT_TRUE(fs::exists(path));
+        EXPECT_EQ(fs::file_size(path), S2::Crypto::KEY_SIZE);
+    }
+}
+
+TEST_F(S2NetworkKeysTest, PersistsWith0600Permissions)
+{
+    ASSERT_TRUE(S2::NetworkKeys::loadOrGenerateAll(dir_).has_value());
+    const auto perms = fs::status(dir_ / S2::NetworkKeys::fileName(Class::AccessControl)).permissions();
+    EXPECT_EQ(perms & fs::perms::group_all, fs::perms::none);
+    EXPECT_EQ(perms & fs::perms::others_all, fs::perms::none);
+    EXPECT_NE(perms & fs::perms::owner_read, fs::perms::none);
+}
+
+TEST_F(S2NetworkKeysTest, LoadsExistingUnchanged)
+{
+    const auto first = S2::NetworkKeys::loadOrGenerateAll(dir_);
+    ASSERT_TRUE(first.has_value());
+    const auto second = S2::NetworkKeys::loadOrGenerateAll(dir_);
+    ASSERT_TRUE(second.has_value());
+    for (std::size_t i = 0; i < S2::NetworkKeys::CLASS_COUNT; ++i)
+    {
+        EXPECT_FALSE(second->generated.at(i));  // read from disk, not regenerated
+        EXPECT_EQ(first->keys.at(i), second->keys.at(i));
+    }
+}
+
+TEST_F(S2NetworkKeysTest, ClassKeysAreDistinct)
+{
+    const auto loaded = S2::NetworkKeys::loadOrGenerateAll(dir_);
+    ASSERT_TRUE(loaded.has_value());
+    std::set<S2::Crypto::Key> unique(loaded->keys.begin(), loaded->keys.end());
+    EXPECT_EQ(unique.size(), S2::NetworkKeys::CLASS_COUNT);  // all four differ
+}
+
+TEST(S2NetworkKeysResolveDir, ExplicitDirWins)
+{
+    EXPECT_EQ(S2::NetworkKeys::resolveDir("/etc/zwaved/keys/s2", "/var/lib/zwaved"), fs::path("/etc/zwaved/keys/s2"));
+}
+
+TEST(S2NetworkKeysResolveDir, DefaultsUnderStateDir)
+{
+    EXPECT_EQ(S2::NetworkKeys::resolveDir("", "/srv/state"), fs::path("/srv/state/security/s2"));
+}
+
+TEST(S2NetworkKeysFileName, OnePerClass)
+{
+    EXPECT_EQ(S2::NetworkKeys::fileName(Class::Unauthenticated), "unauth.key");
+    EXPECT_EQ(S2::NetworkKeys::fileName(Class::Authenticated), "auth.key");
+    EXPECT_EQ(S2::NetworkKeys::fileName(Class::AccessControl), "access.key");
+    EXPECT_EQ(S2::NetworkKeys::fileName(Class::S0Compat), "s0compat.key");
+}


### PR DESCRIPTION
Closes #180. **Phase 2** of the Security S2 epic (#27) — the four per-class network keys (mirrors S0 #163, scaled to a key set).

## What's here
- **`NetworkKeys.{hpp,cpp}`** — `Class` enum (Unauthenticated / Authenticated / Access Control / S0-compat) + `KeySet`; pure load-or-generate of each class key at `<dir>/{unauth,auth,access,s0compat}.key` (mode `0600`, `O_CREAT|O_EXCL`, re-read on a create race), `resolveDir`, in-process `current()`/`setCurrent()`.
- **Config** — new `[security] s2_key_dir`, published via `SecurityConfig.s2KeyDir` (default `<state_dir>/security/s2/`).
- **`NetworkKeysService.cpp`** — constructor-armed (`CONFIG_SECURITY_PRIO`): resolves the dir from `SecurityConfig` + `StorageConfig`, loads/generates all four at startup, sets the in-process set, publishes retained **`S2NetworkKeysReady`**. Generation logged via `Logger::warn` (audit + back-up reminder); failure → `DaemonError CODE_S2_KEYS_FAILED`, degrades to "S2 unavailable".
- **7 tests**: generate-all-on-first-use, `0600` perms, load-existing-unchanged, class keys distinct, dir resolution, file names.
- `etc/zwaved.conf` + CLAUDE.md documented.

## Deferred
Optional D-Bus `ExportS2NetworkKeys` / `ImportS2NetworkKeys` — gated behind per-method auth (#38).

## Verification
Through the exact `docker build` CI runs: `build` (gnu), `build-llvm` (clang-20) — both **397/397 ctest** (390 + 7 new) — and `bootstrap-smoke`. clang-tidy + clang-format in-image, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)