### PR TITLE
feat(s2): CKDF key derivations for S2 bootstrap (part of #187)

### DIFF
--- a/src/zwave-protocol/security/s2/CMakeLists.txt
+++ b/src/zwave-protocol/security/s2/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(zwaved PRIVATE
     Crypto.cpp
     NetworkKeys.cpp
     Span.cpp
+    KeyDerivation.cpp
     Encapsulation.cpp
     Kex.cpp
     PublicKey.cpp

--- a/src/zwave-protocol/security/s2/KeyDerivation.cpp
+++ b/src/zwave-protocol/security/s2/KeyDerivation.cpp
@@ -1,0 +1,85 @@
+#include "KeyDerivation.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+constexpr std::uint8_t CONST_PRK_BYTE  = 0x33;  // CKDF-TempExtract CMAC key, ×16
+constexpr std::size_t CONST_PRK_LEN    = 16;
+constexpr std::uint8_t CONST_TE_BYTE   = 0x88;  // CKDF-TempExpand constant, ×15
+constexpr std::uint8_t CONST_NK_BYTE   = 0x55;  // CKDF-NetworkKeyExpand constant, ×15
+constexpr std::size_t CONST_EXPAND_LEN = 15;
+
+// Generic CKDF expand: T1 = CMAC(prk, const|0x01), Ti = CMAC(prk, T(i-1)|const|i),
+// for i in 1..blocks. Returns T1..Tblocks.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): const byte vs block count are distinct roles
+auto ckdfExpand(const S2::Crypto::Key& prk, std::uint8_t constByte, int blocks) -> std::vector<S2::Crypto::Mac>
+{
+    std::vector<S2::Crypto::Mac> chain;
+    chain.reserve(static_cast<std::size_t>(blocks));
+    for (int index = 1; index <= blocks; ++index)
+    {
+        std::vector<std::uint8_t> msg;
+        if (index > 1)
+        {
+            const auto& prev = chain.back();
+            msg.insert(msg.end(), prev.begin(), prev.end());
+        }
+        msg.insert(msg.end(), CONST_EXPAND_LEN, constByte);
+        msg.push_back(static_cast<std::uint8_t>(index));
+        chain.push_back(S2::Crypto::cmac(prk, std::span<const std::uint8_t>(msg)));
+    }
+    return chain;
+}
+
+// Concatenate two 16-byte MACs into a 32-byte personalization string.
+auto join(const S2::Crypto::Mac& low, const S2::Crypto::Mac& high) -> S2::KeyDerivation::Personalization
+{
+    S2::KeyDerivation::Personalization out{};
+    std::copy(low.begin(), low.end(), out.begin());
+    std::copy(high.begin(), high.end(), out.begin() + low.size());
+    return out;
+}
+}  // namespace
+
+auto S2::KeyDerivation::tempExtract(const Crypto::SharedSecret& sharedSecret,
+                                    const Crypto::PublicKey& controllerPublicKey,
+                                    const Crypto::PublicKey& nodePublicKey) -> Crypto::Key
+{
+    Crypto::Key constPrk{};
+    constPrk.fill(CONST_PRK_BYTE);
+
+    std::vector<std::uint8_t> message;
+    message.reserve(sharedSecret.size() + controllerPublicKey.size() + nodePublicKey.size());
+    message.insert(message.end(), sharedSecret.begin(), sharedSecret.end());
+    message.insert(message.end(), controllerPublicKey.begin(), controllerPublicKey.end());
+    message.insert(message.end(), nodePublicKey.begin(), nodePublicKey.end());
+
+    static_assert(CONST_PRK_LEN == std::tuple_size_v<Crypto::Key>);
+    return Crypto::cmac(constPrk, std::span<const std::uint8_t>(message));
+}
+
+auto S2::KeyDerivation::tempExpand(const Crypto::Key& prk) -> TempKeys
+{
+    const auto chain = ckdfExpand(prk, CONST_TE_BYTE, 3);  // T1..T3
+    return TempKeys{.keyCcm = chain[0], .personalization = join(chain[1], chain[2])};
+}
+
+auto S2::KeyDerivation::deriveTempKeys(const Crypto::SharedSecret& sharedSecret,
+                                       const Crypto::PublicKey& controllerPublicKey,
+                                       const Crypto::PublicKey& nodePublicKey) -> TempKeys
+{
+    return tempExpand(tempExtract(sharedSecret, controllerPublicKey, nodePublicKey));
+}
+
+auto S2::KeyDerivation::networkKeyExpand(const Crypto::Key& networkKey) -> NetworkKeys
+{
+    const auto chain = ckdfExpand(networkKey, CONST_NK_BYTE, 4);  // T1..T4
+    return NetworkKeys{.keyCcm = chain[0], .personalization = join(chain[1], chain[2]), .keyMpan = chain[3]};
+}

--- a/src/zwave-protocol/security/s2/KeyDerivation.hpp
+++ b/src/zwave-protocol/security/s2/KeyDerivation.hpp
@@ -1,0 +1,60 @@
+#ifndef ZWAVED_S2_KEY_DERIVATION_HPP
+#define ZWAVED_S2_KEY_DERIVATION_HPP
+
+// IWYU pragma: begin_exports
+#include "Crypto.hpp"  // S2::Crypto::Key / PublicKey / SharedSecret
+// IWYU pragma: end_exports
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+/// Security S2 (CC 0x9F) CKDF key derivations — part of the inclusion bootstrap
+/// (#27 / #187). Two CMAC-based KDFs from SDS13783 §4.2.6.4.10-13:
+///   - the *temporary* keys (TempKeyCCM + TempPersonalizationString) protect
+///     the bootstrap channel, derived from the ECDH shared secret + both public
+///     keys;
+///   - the *permanent* per-network-key trio (KeyCCM, PersonalizationString,
+///     KeyMPAN) protects normal traffic once a class key is installed.
+namespace S2::KeyDerivation
+{
+constexpr std::size_t PERSONALIZATION_SIZE = 32;
+using Personalization                      = std::array<std::uint8_t, PERSONALIZATION_SIZE>;
+
+/// Temporary keys for the bootstrap secure channel.
+struct TempKeys
+{
+    Crypto::Key keyCcm{};
+    Personalization personalization{};
+};
+
+/// The permanent trio derived from one network (class) key.
+struct NetworkKeys
+{
+    Crypto::Key keyCcm{};
+    Personalization personalization{};
+    Crypto::Key keyMpan{};
+};
+
+/// CKDF-TempExtract: PRK = CMAC(0x33·16, ECDH_shared ‖ KeyPub_controller ‖
+/// KeyPub_node). The two public keys must be in including-then-joining order.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): shared/controller/node are distinct, fixed-order inputs
+[[nodiscard]] auto tempExtract(const Crypto::SharedSecret& sharedSecret,
+                               const Crypto::PublicKey& controllerPublicKey,
+                               const Crypto::PublicKey& nodePublicKey) -> Crypto::Key;
+
+/// CKDF-TempExpand: derive {TempKeyCCM, TempPersonalizationString} from the PRK.
+[[nodiscard]] auto tempExpand(const Crypto::Key& prk) -> TempKeys;
+
+/// Convenience: tempExtract followed by tempExpand.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): shared/controller/node are distinct, fixed-order inputs
+[[nodiscard]] auto deriveTempKeys(const Crypto::SharedSecret& sharedSecret,
+                                  const Crypto::PublicKey& controllerPublicKey,
+                                  const Crypto::PublicKey& nodePublicKey) -> TempKeys;
+
+/// CKDF-NetworkKeyExpand: derive {KeyCCM, PersonalizationString, KeyMPAN} from a
+/// network (class) key.
+[[nodiscard]] auto networkKeyExpand(const Crypto::Key& networkKey) -> NetworkKeys;
+}  // namespace S2::KeyDerivation
+
+#endif  // ZWAVED_S2_KEY_DERIVATION_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -440,6 +440,20 @@ target_link_libraries(s2_encapsulation_test PRIVATE GTest::gtest GTest::gtest_ma
 zwaved_test_target(s2_encapsulation_test)
 gtest_discover_tests(s2_encapsulation_test)
 
+# ---- S2 key derivation ----------------------------------------------
+# Security S2 (CC 0x9F) phase 9 crypto: CKDF temp + network key derivations.
+add_executable(s2_key_derivation_test
+    s2_key_derivation_test.cpp
+    "${SRC_DIR}/security/s2/KeyDerivation.cpp"
+    "${SRC_DIR}/security/s2/Crypto.cpp"
+)
+target_include_directories(s2_key_derivation_test PRIVATE
+    "${SRC_DIR}/security/s2"
+)
+target_link_libraries(s2_key_derivation_test PRIVATE GTest::gtest GTest::gtest_main PkgConfig::OPENSSL)
+zwaved_test_target(s2_key_derivation_test)
+gtest_discover_tests(s2_key_derivation_test)
+
 # ---- S2 SPAN --------------------------------------------------------
 # Security S2 (CC 0x9F) phase 3: CTR_DRBG SPAN nonce protocol.
 add_executable(s2_span_test

--- a/tests/s2_key_derivation_test.cpp
+++ b/tests/s2_key_derivation_test.cpp
@@ -1,0 +1,96 @@
+// Security S2 (CC 0x9F) CKDF key derivations (#187). No published CKDF vectors,
+// so these pin the spec formulas against an independent CMAC computation (CMAC
+// itself is NIST-KAT-verified in s2_crypto_test) + determinism / distinctness.
+
+#include "Crypto.hpp"
+#include "KeyDerivation.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+const S2::Crypto::SharedSecret SHARED{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+                                      17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
+const S2::Crypto::PublicKey CONTROLLER_PUB{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA,
+                                           0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5,
+                                           0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF};
+const S2::Crypto::PublicKey NODE_PUB{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A,
+                                     0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                                     0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F};
+
+// CMAC(prk, const·constLen ‖ index) — one CKDF expand block, chained on `prev`.
+auto block(const S2::Crypto::Key& prk,
+           const S2::Crypto::Mac* prev,
+           std::uint8_t constByte,
+           std::uint8_t index) -> S2::Crypto::Mac
+{
+    std::vector<std::uint8_t> msg;
+    if (prev != nullptr)
+    {
+        msg.insert(msg.end(), prev->begin(), prev->end());
+    }
+    msg.insert(msg.end(), 15, constByte);
+    msg.push_back(index);
+    return S2::Crypto::cmac(prk, std::span<const std::uint8_t>(msg));
+}
+}  // namespace
+
+TEST(S2KeyDerivation, TempExtractIsDeterministicAndOrderSensitive)
+{
+    EXPECT_EQ(S2::KeyDerivation::tempExtract(SHARED, CONTROLLER_PUB, NODE_PUB),
+              S2::KeyDerivation::tempExtract(SHARED, CONTROLLER_PUB, NODE_PUB));
+    // Swapping the public-key order changes the PRK (AAD-style ordering matters).
+    EXPECT_NE(S2::KeyDerivation::tempExtract(SHARED, CONTROLLER_PUB, NODE_PUB),
+              S2::KeyDerivation::tempExtract(SHARED, NODE_PUB, CONTROLLER_PUB));
+}
+
+TEST(S2KeyDerivation, TempExpandMatchesSpecFormula)
+{
+    const auto prk  = S2::KeyDerivation::tempExtract(SHARED, CONTROLLER_PUB, NODE_PUB);
+    const auto temp = S2::KeyDerivation::tempExpand(prk);
+
+    const auto t1 = block(prk, nullptr, 0x88, 0x01);
+    const auto t2 = block(prk, &t1, 0x88, 0x02);
+    const auto t3 = block(prk, &t2, 0x88, 0x03);
+
+    EXPECT_EQ(temp.keyCcm, t1);  // TempKeyCCM = T1
+    // TempPersonalizationString = T2 ‖ T3
+    EXPECT_TRUE(std::equal(t2.begin(), t2.end(), temp.personalization.begin()));
+    EXPECT_TRUE(std::equal(t3.begin(), t3.end(), temp.personalization.begin() + t2.size()));
+}
+
+TEST(S2KeyDerivation, NetworkKeyExpandMatchesSpecFormula)
+{
+    const S2::Crypto::Key networkKey{
+        0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F};
+    const auto derived = S2::KeyDerivation::networkKeyExpand(networkKey);
+
+    const auto t1 = block(networkKey, nullptr, 0x55, 0x01);
+    const auto t2 = block(networkKey, &t1, 0x55, 0x02);
+    const auto t3 = block(networkKey, &t2, 0x55, 0x03);
+    const auto t4 = block(networkKey, &t3, 0x55, 0x04);
+
+    EXPECT_EQ(derived.keyCcm, t1);   // KeyCCM = T1
+    EXPECT_EQ(derived.keyMpan, t4);  // KeyMPAN = T4
+    EXPECT_TRUE(std::equal(t2.begin(), t2.end(), derived.personalization.begin()));
+    EXPECT_TRUE(std::equal(t3.begin(), t3.end(), derived.personalization.begin() + t2.size()));
+}
+
+TEST(S2KeyDerivation, DistinctInputsDeriveDistinctKeys)
+{
+    const auto temp  = S2::KeyDerivation::deriveTempKeys(SHARED, CONTROLLER_PUB, NODE_PUB);
+    auto otherShared = SHARED;
+    otherShared.at(0) ^= 0x01;
+    const auto temp2 = S2::KeyDerivation::deriveTempKeys(otherShared, CONTROLLER_PUB, NODE_PUB);
+    EXPECT_NE(temp.keyCcm, temp2.keyCcm);
+
+    const S2::Crypto::Key keyA{0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    const S2::Crypto::Key keyB{0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    EXPECT_NE(S2::KeyDerivation::networkKeyExpand(keyA).keyCcm, S2::KeyDerivation::networkKeyExpand(keyB).keyCcm);
+}


### PR DESCRIPTION
First layer of the S2 inclusion-bootstrap work (#187).

## What

Two CMAC-based key-derivation functions from SDS13783 §4.2.6.4.10–13, in `src/zwave-protocol/security/s2/KeyDerivation.{hpp,cpp}`:

- **CKDF-TempExtract / CKDF-TempExpand** — derive the temporary bootstrap-channel keys (`TempKeyCCM` + `TempPersonalizationString`) from the ECDH shared secret and both public keys.
- **CKDF-NetworkKeyExpand** — derive the permanent per-class trio (`KeyCCM` + `PersonalizationString` + `KeyMPAN`) from a network (class) key.

Pure codec on top of the existing `S2::Crypto::cmac` primitive — no I/O, no device dependency, so fully unit-testable on the bench.

## Tests

No published CKDF test vectors exist, so `tests/s2_key_derivation_test.cpp` pins the spec formulas against an independent CMAC computation (CMAC itself is NIST-KAT-verified in `s2_crypto_test`), plus determinism, public-key order-sensitivity, and input distinctness. 437/437 ctest green on both gnu and llvm presets; clang-format + clang-tidy clean.

## Scope

This is the first of several PRs composing #187. Later layers add the runtime SPAN / nonce exchange and the KEX state-machine orchestrator (KEX → temp-channel → public-key/DSK → per-class key install → transfer-end), which are only fully verifiable against real hardware (#189).

Part of #187 / the S2 epic #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)