### PR TITLE
feat(s2): DSK confirmation ritual for inclusion bootstrap (part of #187)

### DIFF
--- a/InterfaceManifest.yml
+++ b/InterfaceManifest.yml
@@ -206,6 +206,38 @@ events:
     fields:
       - { name: nodeId, type: u8, default: 0 }
 
+  - name: DSKPendingConfirmation
+    category: state
+    direction: { publishers: [orchestrator], subscribers: [external-api] }
+    doc: |
+      SecurityS2BootstrapOrchestrator (#187) is waiting for the operator to
+      confirm a joining node's DSK (Device Specific Key) before it can finish
+      S2 key agreement for an Authenticated / Access Control grant. The joining
+      node obfuscated the first DSK group (the PIN) in its PUBLIC_KEY_REPORT, so
+      `dsk` is the *partial* DSK string with that first group shown as 00000 —
+      the operator reads the full DSK off the device label and supplies the
+      missing 5-digit PIN via ConfirmDSK. Retained so a client (terminal)
+      connecting after the prompt still sees the pending confirmation; the
+      orchestrator publishes a cleared value (nodeId 0, empty dsk) once the PIN
+      is supplied (or the session ends), mirroring the DaemonError convention.
+    fields:
+      - { name: nodeId, type: u8,     default: 0 }
+      - { name: dsk,    type: string }
+
+  - name: ConfirmDsk
+    category: command
+    direction: { publishers: [external-api], subscribers: [orchestrator] }
+    doc: |
+      The operator's answer to a DSKPendingConfirmation: the 5-digit DSK PIN
+      (first DSK group) for node `nodeId`, read off the device label. The
+      SecurityS2BootstrapOrchestrator restores the obfuscated public-key bytes
+      from it and resumes S2 key agreement. A malformed PIN is ignored (the
+      prompt stays up); a wrong-but-well-formed PIN only surfaces later, as the
+      encrypted KEX echo fails to authenticate (a later #187 layer).
+    fields:
+      - { name: nodeId, type: u8,     default: 0 }
+      - { name: pin,    type: string }
+
   - name: DaemonError
     category: state
     direction: { publishers: [zwave-protocol, zwave-dongle, external-api, config], subscribers: [external-api] }
@@ -2021,6 +2053,13 @@ dbus:
       action:
         publish: SendWakeUpNoMoreInformationCommand
 
+    - name: ConfirmDSK
+      params:
+        - { name: nodeId, dbus: y, cpp: u8 }
+        - { name: pin,    dbus: s, cpp: string, doc: "5-digit first DSK group read off the device label" }
+      action:
+        publish: ConfirmDsk
+
     - name: SetAssociation
       params:
         - { name: nodeId,     dbus: y,  cpp: u8 }
@@ -2434,6 +2473,12 @@ dbus:
         - { name: nodeId, dbus: y }
         - { name: scheme, dbus: y }
       triggered_by: { event: NodeSecurityStatus }
+
+    - name: DSKPendingConfirmation
+      params:
+        - { name: nodeId, dbus: y }
+        - { name: dsk,    dbus: s }
+      triggered_by: { event: DSKPendingConfirmation }
 
     - name: InitData
       params:

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -966,6 +966,33 @@ and typed forms above work unchanged — no client-side handling needed:
   (fetching a fresh nonce per message). The full S0 wire path is pending
   end-to-end verification on real hardware (#168).
 
+- **Security S2 (CC `0x9F`, #27)** — second-generation encrypted transport
+  (AES-128-CCM + Curve25519 ECDH inclusion + per-class network keys). Built in
+  layers; the inclusion **key-agreement** phase is wired today. When a
+  newly-included node advertises CC `0x9F`, the daemon runs the KEX handshake
+  (`KEX_GET → KEX_REPORT → KEX_SET`), exchanges public keys, and — once it has
+  the node's full public key — derives the temporary bootstrap-channel keys via
+  ECDH. For the **Authenticated / Access Control** classes the joining node
+  obfuscates the first group of its DSK (Device Specific Key), so the daemon
+  raises a **`DSKPendingConfirmation(nodeId, dsk)`** signal (retained, so a
+  client connecting after the prompt still sees it). `dsk` is the *partial* DSK
+  with the first group shown as `00000`; read the full DSK off the device label
+  and supply the missing 5-digit PIN:
+
+  ```bash
+  busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
+      com.tiunda.ZWaved1 ConfirmDSK ys 12 "54321"
+  ```
+
+  The daemon restores the obfuscated key bytes from the PIN and resumes key
+  agreement (an `S2 Unauthenticated` node needs no PIN and proceeds straight
+  through). A malformed PIN is ignored and the prompt stays up; a
+  well-formed-but-wrong PIN only fails later, when the encrypted handshake can't
+  authenticate. The remaining S2 phases — the encrypted temp-channel key
+  install, live transport encapsulation, and on-bench acceptance — are in
+  progress (#187 / #199 / #189); the S2 wire path is unverified against real
+  hardware until #189.
+
 ## 13. Listing nodes
 
 `GetNodes` returns the daemon's in-memory list of currently-included

--- a/TODO.md
+++ b/TODO.md
@@ -125,8 +125,9 @@ Implementation order (each shippable independently):
   - [ ] [#187](https://github.com/Assar63/zwaved/issues/187) phase 9 — inclusion bootstrap wiring (in progress, built in layers):
     - [x] [#202](https://github.com/Assar63/zwaved/issues/202) CKDF key derivations (TempExtract/Expand + NetworkKeyExpand)
     - [x] plaintext key-agreement phase — `SecurityS2BootstrapOrchestrator` (KEX negotiation → public-key exchange → ECDH → temp-key derivation; Unauthenticated completes, DSK grants park at `AwaitDsk`)
-    - [ ] DSK operator ritual (PIN confirm) + KEX_FAIL-on-bad-PIN, with the `DSKPendingConfirmation` signal / `ConfirmDSK` D-Bus method + terminal prompt
-    - [ ] encrypted temp-channel phase — KEX echo verify + per-class `NETWORK_KEY_REPORT` install + `NETWORK_KEY_VERIFY` + `TRANSFER_END` over SPAN + AES-128-CCM (needs SPAN runtime sync, #199)
+    - [x] DSK operator ritual — `DSKPendingConfirmation` signal (retained, partial DSK) + `ConfirmDSK` D-Bus method → PIN applied → key agreement resumes (malformed PIN ignored; wrong-but-well-formed PIN surfaces later at the encrypted echo)
+    - [ ] terminal DSK prompt UX (zwave-terminal, under #73) — surface `DSKPendingConfirmation` + a PIN-entry binding calling `ConfirmDSK`
+    - [ ] encrypted temp-channel phase — KEX echo verify (KEX_FAIL on bad PIN here) + per-class `NETWORK_KEY_REPORT` install + `NETWORK_KEY_VERIFY` + `TRANSFER_END` over SPAN + AES-128-CCM (needs SPAN runtime sync, #199)
   - [ ] [#188](https://github.com/Assar63/zwaved/issues/188) phase 10 — MPAN (multicast, optional)
   - [ ] [#189](https://github.com/Assar63/zwaved/issues/189) phase 11 — on-bench acceptance (hardware)
 - [x] **CRC-16 Encapsulation (CC `0x56`)** — [#28](https://github.com/Assar63/zwaved/issues/28): transport-only integrity wrapper. `Crc16Encap` codec (CRC-16/AUG-CCITT `checksum` + `verifyAndUnwrap` + `encode`); a hand-written inbound unwrapper (`src/cc-translator/Encapsulation.cpp`) verifies the CRC and republishes the inner frame as an `ApplicationCommand` so the normal decoders fire (bad CRC → dropped + warned). No D-Bus/terminal surface. 6 codec tests. This establishes the inbound-unwrap seam that Transport Service (#25) and the Multi Channel reply-unwrap (#146) plug into.

--- a/src/orchestrator/SecurityS2BootstrapOrchestrator.cpp
+++ b/src/orchestrator/SecurityS2BootstrapOrchestrator.cpp
@@ -3,24 +3,26 @@
 // the per-class network keys. Bus-only, like the other orchestrators
 // (constructor priority 204).
 //
-// This is the *plaintext key-agreement* phase — the first #187 layer. When an
-// included node's NIF advertises CC 0x9F and the S2 network keys exist:
+// This is the *plaintext key-agreement* phase (+ DSK ritual). When an included
+// node's NIF advertises CC 0x9F and the S2 network keys exist:
 //   1. KEX_GET                         (plaintext) -> node replies KEX_REPORT
 //   2. grant = requested ∩ supported (deny Access Control to a CSA node);
 //      KEX_SET with the granted classes -> node sends its PUBLIC_KEY_REPORT
-//   3. We reply with our PUBLIC_KEY_REPORT (un-obfuscated), then — for a grant
-//      that needs no DSK (S2 Unauthenticated only) — compute the ECDH shared
-//      secret and derive the temporary bootstrap-channel keys
-//      (CKDF-TempExtract/Expand, #202), and publish S2KeyAgreementComplete.
+//   3. We reply with our PUBLIC_KEY_REPORT (un-obfuscated). For an
+//      Authenticated / Access Control grant the node obfuscated the first DSK
+//      group, so we raise DSKPendingConfirmation and wait for the operator's
+//      ConfirmDsk (the 5-digit PIN off the device label), which restores the
+//      obfuscated key bytes. For S2 Unauthenticated there's no PIN.
+//   4. Once we hold the node's full public key, compute the ECDH shared secret
+//      and derive the temporary bootstrap-channel keys (CKDF-TempExtract/
+//      Expand, #202), and publish S2KeyAgreementComplete.
 //
 // Deferred to later #187 layers (all unverifiable until hardware, #189):
-//   - the DSK ritual for Authenticated / Access Control (the node obfuscates
-//     the first key bytes; the operator types the PIN). Here a DSK-requiring
-//     grant parks the session at AwaitDsk and goes no further;
-//   - the encrypted temp-channel phase: KEX echo verify, per-class
+//   - the encrypted temp-channel phase: KEX echo verify (where a wrong-but-
+//     well-formed DSK PIN finally surfaces as KEX_FAIL), per-class
 //     NETWORK_KEY_REPORT install, NETWORK_KEY_VERIFY, TRANSFER_END — over SPAN
 //     + AES-128-CCM (needs the SPAN runtime nonce sync, #199);
-//   - the operator D-Bus / terminal progress + DSK confirmation surface.
+//   - the terminal DSK prompt UX (the D-Bus surface lands here).
 //
 // Single-session assumption: like the S0 bootstrap, concurrent inclusions are
 // disambiguated only by source node id; there is no inactivity timeout (a
@@ -72,6 +74,7 @@ struct Session
     Phase phase = Phase::AwaitKexReport;
     S2::Crypto::KeyPair keyPair{};
     std::uint8_t grantedKeys = 0;
+    S2::Crypto::PublicKey nodePublicKey{};  // the joining node's key (DSK-obfuscated until the PIN is applied)
     S2::KeyDerivation::TempKeys tempKeys{};
 };
 
@@ -80,6 +83,7 @@ struct State
 {
     MessageBus::SubscriptionGuard includedSub;
     MessageBus::SubscriptionGuard appCmdSub;
+    MessageBus::SubscriptionGuard confirmDskSub;
     MessageBus::SubscriptionGuard dongleSub;
     MessageBus::SubscriptionGuard keysSub;
     std::map<std::uint8_t, Session> sessions;  // per-node handshake progress
@@ -150,29 +154,18 @@ auto onKexReport(std::uint8_t nodeId, Session& session, std::span<const std::uin
                                                   .grantedKeys    = granted}));
 }
 
-auto onPublicKeyReport(std::uint8_t nodeId, Session& session, std::span<const std::uint8_t> ccData) -> void
+// Retract a pending DSK prompt (empty value = "nothing pending"), mirroring the
+// DaemonError "recovered" convention.
+auto clearDskPrompt() -> void
 {
-    const auto report = S2::PublicKey::decode(ccData);
-    if (!report.has_value())
-    {
-        return;
-    }
-    // Answer with our (controller, including-node) public key, un-obfuscated.
-    sendPlaintext(nodeId, S2::PublicKey::encode(true, session.keyPair.publicKey, S2::PublicKey::OBFUSCATE_NONE));
+    MessageBus::publish(MessageBus::DSKPendingConfirmation{.nodeId = 0, .dsk = {}});
+}
 
-    if ((session.grantedKeys & DSK_REQUIRED_KEYS) != 0)
-    {
-        // Authenticated / Access Control: the node obfuscated its leading key
-        // bytes. We need the operator's DSK PIN to restore them before ECDH —
-        // that ritual is the next #187 layer, so park the session here.
-        session.phase = Phase::AwaitDsk;
-        Logger::info("[s2-bootstrap] node " + std::to_string(nodeId) +
-                     " granted an authenticated class — DSK confirmation required (deferred)");
-        return;
-    }
-
-    // S2 Unauthenticated: no obfuscation, so we can finish key agreement now.
-    const auto shared = S2::Crypto::ecdh(session.keyPair.privateKey, report->key);
+// Final step shared by the Unauthenticated and DSK-confirmed paths: ECDH against
+// the node's (de-obfuscated) public key, derive the temp channel keys, advance.
+auto finishKeyAgreement(std::uint8_t nodeId, Session& session) -> void
+{
+    const auto shared = S2::Crypto::ecdh(session.keyPair.privateKey, session.nodePublicKey);
     if (!shared.has_value())
     {
         Logger::warn("[s2-bootstrap] ECDH failed for node " + std::to_string(nodeId) + " — KEX_FAIL");
@@ -180,11 +173,63 @@ auto onPublicKeyReport(std::uint8_t nodeId, Session& session, std::span<const st
         state().sessions.erase(nodeId);
         return;
     }
-    session.tempKeys = S2::KeyDerivation::deriveTempKeys(*shared, session.keyPair.publicKey, report->key);
+    session.tempKeys = S2::KeyDerivation::deriveTempKeys(*shared, session.keyPair.publicKey, session.nodePublicKey);
     session.phase    = Phase::AwaitTempChannel;
     Logger::info("[s2-bootstrap] node " + std::to_string(nodeId) +
                  " key agreement complete — temporary channel keys derived");
     MessageBus::publish(MessageBus::S2KeyAgreementComplete{.nodeId = nodeId});
+}
+
+auto onPublicKeyReport(std::uint8_t nodeId, Session& session, std::span<const std::uint8_t> ccData) -> void
+{
+    const auto report = S2::PublicKey::decode(ccData);
+    if (!report.has_value())
+    {
+        return;
+    }
+    session.nodePublicKey = report->key;
+    // Answer with our (controller, including-node) public key, un-obfuscated.
+    sendPlaintext(nodeId, S2::PublicKey::encode(true, session.keyPair.publicKey, S2::PublicKey::OBFUSCATE_NONE));
+
+    if ((session.grantedKeys & DSK_REQUIRED_KEYS) != 0)
+    {
+        // Authenticated / Access Control: the node obfuscated its leading key
+        // bytes (the DSK PIN). Park until the operator supplies it via
+        // ConfirmDSK; the partial DSK (first group shown as 00000) lets them
+        // match the prompt against the device label.
+        session.phase = Phase::AwaitDsk;
+        Logger::info("[s2-bootstrap] node " + std::to_string(nodeId) +
+                     " granted an authenticated class — awaiting operator DSK confirmation");
+        MessageBus::publish(
+            MessageBus::DSKPendingConfirmation{.nodeId = nodeId, .dsk = S2::PublicKey::dskString(report->key)});
+        return;
+    }
+
+    // S2 Unauthenticated: no obfuscation, so we can finish key agreement now.
+    finishKeyAgreement(nodeId, session);
+}
+
+auto onConfirmDsk(const MessageBus::ConfirmDsk& event) -> void
+{
+    const auto session = state().sessions.find(event.nodeId);
+    if (session == state().sessions.end() || session->second.phase != Phase::AwaitDsk)
+    {
+        return;  // no node is waiting on a DSK for this id
+    }
+    const auto pin = S2::PublicKey::parsePin(event.pin);
+    if (!pin.has_value())
+    {
+        Logger::warn("[s2-bootstrap] node " + std::to_string(event.nodeId) +
+                     " DSK confirmation ignored — PIN must be exactly 5 digits");
+        return;  // leave the prompt up for a retry
+    }
+    // Restore the obfuscated leading key bytes from the PIN, then agree keys. A
+    // wrong-but-well-formed PIN yields the wrong shared secret and only surfaces
+    // when the encrypted KEX echo fails to authenticate (a later #187 layer).
+    session->second.nodePublicKey = S2::PublicKey::applyPin(session->second.nodePublicKey, *pin);
+    Logger::info("[s2-bootstrap] node " + std::to_string(event.nodeId) + " DSK confirmed — resuming key agreement");
+    clearDskPrompt();
+    finishKeyAgreement(event.nodeId, session->second);
 }
 
 auto onApplicationCommand(const MessageBus::ApplicationCommand& event) -> void
@@ -227,9 +272,10 @@ __attribute__((constructor(CONFIG_ORCHESTRATOR_PRIO))) auto startSecurityS2Boots
         MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::NodeIncluded>(onNodeIncluded));
     state().appCmdSub =
         MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::ApplicationCommand>(onApplicationCommand));
-    state().dongleSub = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::DongleInfo>(
+    state().confirmDskSub = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::ConfirmDsk>(onConfirmDsk));
+    state().dongleSub     = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::DongleInfo>(
         [](const MessageBus::DongleInfo& info) -> void { state().controllerNodeId = info.controllerNodeId; }));
-    state().keysSub   = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::S2NetworkKeysReady>(
+    state().keysSub       = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::S2NetworkKeysReady>(
         [](const MessageBus::S2NetworkKeysReady& event) -> void { state().keysReady = event.ready; }));
 }
 }  // namespace

--- a/tests/s2_bootstrap_test.cpp
+++ b/tests/s2_bootstrap_test.cpp
@@ -35,8 +35,10 @@ struct Harness
 {
     std::vector<MessageBus::SendDataCommand> sent;
     std::optional<MessageBus::S2KeyAgreementComplete> agreed;
+    std::vector<MessageBus::DSKPendingConfirmation> dskPrompts;
     MessageBus::SubscriptionGuard sentGuard;
     MessageBus::SubscriptionGuard agreedGuard;
+    MessageBus::SubscriptionGuard dskGuard;
 
     Harness()
     {
@@ -46,6 +48,18 @@ struct Harness
             [this](const MessageBus::SendDataCommand& cmd) -> void { sent.push_back(cmd); }));
         agreedGuard = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::S2KeyAgreementComplete>(
             [this](const MessageBus::S2KeyAgreementComplete& event) -> void { agreed = event; }));
+        dskGuard    = MessageBus::SubscriptionGuard(MessageBus::subscribe<MessageBus::DSKPendingConfirmation>(
+            [this](const MessageBus::DSKPendingConfirmation& event) -> void { dskPrompts.push_back(event); }));
+    }
+
+    // Drive a fresh session up to the DSK-pending park: inclusion, KEX_REPORT
+    // for `keys`, then the node's DSK-obfuscated PUBLIC_KEY_REPORT.
+    void driveToDskPending(std::uint8_t keys, const S2::Crypto::PublicKey& nodePublicKey)
+    {
+        MessageBus::publish(MessageBus::NodeIncluded{.nodeId = NODE, .commandClasses = {CC_S2}});
+        MessageBus::publish(MessageBus::ApplicationCommand{.sourceNodeId = NODE, .ccData = kexReport(keys)});
+        MessageBus::publish(MessageBus::ApplicationCommand{
+            .sourceNodeId = NODE, .ccData = S2::PublicKey::encode(false, nodePublicKey, S2::PublicKey::OBFUSCATE_DSK)});
     }
 };
 }  // namespace
@@ -89,18 +103,45 @@ TEST(S2Bootstrap, UnauthenticatedReachesKeyAgreement)
 TEST(S2Bootstrap, AuthenticatedGrantParksOnDsk)
 {
     Harness harness;
-    MessageBus::publish(MessageBus::NodeIncluded{.nodeId = NODE, .commandClasses = {CC_S2}});
-    MessageBus::publish(
-        MessageBus::ApplicationCommand{.sourceNodeId = NODE, .ccData = kexReport(S2::Kex::KEY_S2_AUTHENTICATED)});
+    const auto nodeKeys = S2::Crypto::generateKeyPair();
 
     // The node's PUBLIC_KEY_REPORT (DSK-obfuscated) → we answer, but key
-    // agreement does NOT complete (PIN required, deferred to the DSK layer).
-    const auto nodeKeys = S2::Crypto::generateKeyPair();
-    MessageBus::publish(MessageBus::ApplicationCommand{
-        .sourceNodeId = NODE,
-        .ccData       = S2::PublicKey::encode(false, nodeKeys.publicKey, S2::PublicKey::OBFUSCATE_DSK)});
+    // agreement does NOT complete; a DSK prompt is raised instead.
+    harness.driveToDskPending(S2::Kex::KEY_S2_AUTHENTICATED, nodeKeys.publicKey);
     ASSERT_EQ(harness.sent.size(), 3U);  // KEX_GET, KEX_SET, our PUBLIC_KEY_REPORT
     EXPECT_FALSE(harness.agreed.has_value());
+    ASSERT_FALSE(harness.dskPrompts.empty());
+    EXPECT_EQ(harness.dskPrompts.back().nodeId, NODE);
+    EXPECT_FALSE(harness.dskPrompts.back().dsk.empty());
+}
+
+TEST(S2Bootstrap, DskConfirmationCompletesKeyAgreement)
+{
+    Harness harness;
+    const auto nodeKeys = S2::Crypto::generateKeyPair();
+    harness.driveToDskPending(S2::Kex::KEY_S2_AUTHENTICATED, nodeKeys.publicKey);
+    ASSERT_FALSE(harness.agreed.has_value());
+
+    // Operator supplies the PIN (the first DSK group of the node's real key).
+    MessageBus::publish(MessageBus::ConfirmDsk{.nodeId = NODE, .pin = S2::PublicKey::dskPin(nodeKeys.publicKey)});
+
+    ASSERT_TRUE(harness.agreed.has_value());
+    EXPECT_EQ(harness.agreed->nodeId, NODE);
+    // The pending prompt is retracted (nodeId 0, empty dsk).
+    EXPECT_EQ(harness.dskPrompts.back().nodeId, 0);
+    EXPECT_TRUE(harness.dskPrompts.back().dsk.empty());
+}
+
+TEST(S2Bootstrap, MalformedPinKeepsPromptUp)
+{
+    Harness harness;
+    const auto nodeKeys = S2::Crypto::generateKeyPair();
+    harness.driveToDskPending(S2::Kex::KEY_S2_AUTHENTICATED, nodeKeys.publicKey);
+    const auto promptsBefore = harness.dskPrompts.size();
+
+    MessageBus::publish(MessageBus::ConfirmDsk{.nodeId = NODE, .pin = "12"});  // not 5 digits
+    EXPECT_FALSE(harness.agreed.has_value());
+    EXPECT_EQ(harness.dskPrompts.size(), promptsBefore);  // no retract published
 }
 
 TEST(S2Bootstrap, NoGrantableKeyFailsKex)


### PR DESCRIPTION
Next #187 layer, on top of the key-agreement phase (#204): the **DSK operator ritual**, so Authenticated / Access Control nodes (which parked at `AwaitDsk`) can be confirmed and complete key agreement.

## What

When an Authenticated / Access Control grant is in play, the joining node obfuscates the first DSK group (the PIN) in its `PUBLIC_KEY_REPORT`. `SecurityS2BootstrapOrchestrator` now:

- raises a **retained `DSKPendingConfirmation(nodeId, dsk)` signal** — `dsk` is the *partial* DSK (first group shown as `00000`) so the operator can match it against the device label. Retained, so a client (terminal) connecting after the prompt still sees it.
- on the operator's **`ConfirmDSK(y nodeId, s pin)`** D-Bus call → `ConfirmDsk` bus event → restores the obfuscated key bytes from the 5-digit PIN (`PublicKey::applyPin`), then resumes ECDH + temp-key derivation via the same `finishKeyAgreement` path the Unauthenticated flow uses, and retracts the prompt (cleared `DSKPendingConfirmation`, nodeId 0 / empty — mirroring the `DaemonError` "recovered" convention).

```bash
busctl --system call com.tiunda.ZWaved /com/tiunda/ZWaved \
    com.tiunda.ZWaved1 ConfirmDSK ys 12 "54321"
```

A **malformed PIN** (not exactly 5 digits) is ignored and the prompt stays up. A **wrong-but-well-formed PIN** can't be detected here — it only surfaces when the encrypted KEX echo fails to authenticate (a later #187 layer).

## Manifest

- retained `DSKPendingConfirmation{nodeId, dsk}` event + D-Bus signal
- `ConfirmDsk{nodeId, pin}` command event + `ConfirmDSK(ys)` D-Bus method (`action: publish`)

## Tests / docs

`tests/s2_bootstrap_test.cpp` adds: the prompt is raised on an Authenticated grant; a valid PIN completes key agreement and retracts the prompt; a malformed PIN keeps the prompt up. 443/443 ctest green on both gnu and llvm; clang-format + clang-tidy clean. MANUAL.md documents the confirm flow.

Remaining #187 work (tracked in TODO.md): the terminal DSK prompt UX (zwave-terminal, under #73) and the encrypted temp-channel phase (KEX echo verify + per-class key install over SPAN/CCM, needs #199). S2 wire path unverified against real hardware until #189.

Part of #187 / the S2 epic #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)