### PR TITLE
feat(terminal): node-targeted actions default to the selected node (part of #215)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -211,7 +211,7 @@ Implementation order (each shippable independently):
 
 - [ ] **[Master/detail node-console redesign](https://github.com/Assar63/zwaved/issues/215)** — replace the flat `stdscr` redraw with real ncurses panes. Built in steps:
   - [x] console shell — status bar + selectable node list + detail pane (identity + CC list + **live values** from #213, with age) + activity log + scope-grouped hint bar; `nodes.{hpp,cpp}` model, arrow-key selection, periodic value poll, `[a]`/`[x]` add/remove, `[r]` refresh. Realises #45 as the detail pane.
-  - [ ] contextual actions on the selected node — make `[c]`/`[g]`/`[f]`/`[L]` operate on the highlighted node (skip the node-id prompt) instead of always prompting
+  - [x] contextual actions on the selected node — `promptNodeId` now defaults to the highlighted node (label shows `[5]`, Enter accepts, type to override); every node-targeted action (incl. `[f]`/`[L]`, switched off `promptByte`) is contextual through that one choke point
   - [ ] auto-refresh the list on `NodeListChanged` / `NodeValueChanged` signals (today the list refreshes on `[r]` / add-remove; values poll every ~2s)
   - [ ] DSK confirm modal — surface `DSKPendingConfirmation` + a PIN entry calling `ConfirmDSK` (#187), drawn over the panes
 

--- a/utils/zwave-terminal/handlers.cpp
+++ b/utils/zwave-terminal/handlers.cpp
@@ -819,7 +819,7 @@ auto handleGetAssociation(sdbus::IProxy& proxy, std::uint8_t& callbackCounter) -
 
 auto handleSetLifeline(sdbus::IProxy& proxy, std::uint8_t& callbackCounter) -> void
 {
-    auto nodeId = promptByte("Node ID (1-232):", NODE_ID_MIN, NODE_ID_MAX);
+    auto nodeId = promptNodeId("Node ID (1-232):");
     if (!nodeId.has_value())
     {
         logLine("SetAssociation (lifeline): cancelled or invalid node id");
@@ -851,7 +851,7 @@ auto handleSetLifeline(sdbus::IProxy& proxy, std::uint8_t& callbackCounter) -> v
 
 auto handleRemoveFailedNode(sdbus::IProxy& proxy, std::uint8_t& sessionCounter) -> void
 {
-    auto nodeId = promptByte("Failed node ID (1-232):", NODE_ID_MIN, NODE_ID_MAX);
+    auto nodeId = promptNodeId("Failed node ID (1-232):");
     if (!nodeId.has_value())
     {
         logLine("RemoveFailedNode: cancelled or invalid node id");

--- a/utils/zwave-terminal/prompts.cpp
+++ b/utils/zwave-terminal/prompts.cpp
@@ -1,6 +1,7 @@
 #include "prompts.hpp"
 
 #include "constants.hpp"
+#include "nodes.hpp"
 
 #include <array>
 #include <charconv>
@@ -61,7 +62,45 @@ auto promptByte(const char* label, int minVal, int maxVal) -> std::optional<std:
 
 auto promptNodeId(const char* label) -> std::optional<std::uint8_t>
 {
-    return promptByte(label, NODE_ID_MIN, NODE_ID_MAX);
+    // Default to the node selected in the console (#215): the label shows it as
+    // "[5]" and an empty Enter accepts it, so node-targeted actions operate on
+    // the selection without retyping — while still allowing an explicit id. With
+    // no selection this is the plain prompt.
+    const auto selected = selectedNodeId();
+
+    const int rows = getmaxy(stdscr);
+    move(rows - 1, 0);
+    clrtoeol();
+    if (selected.has_value())
+    {
+        mvprintw(rows - 1, 0, "%s [%u] ", label, static_cast<unsigned>(*selected));
+    }
+    else
+    {
+        mvprintw(rows - 1, 0, "%s ", label);
+    }
+    refresh();
+
+    echo();
+    curs_set(1);
+    timeout(-1);  // blocking
+    std::array<char, NODE_ID_INPUT_BUFFER> buffer{};
+    int const got = getnstr(buffer.data(), static_cast<int>(buffer.size()) - 1);
+    noecho();
+    curs_set(0);
+    timeout(UI_REFRESH_MS);
+
+    const std::string text(got == OK ? buffer.data() : "");
+    if (text.empty())
+    {
+        return selected;  // Enter accepts the selection (nullopt cancels if none)
+    }
+    const auto parsed = parseUint(text, NODE_ID_MAX);
+    if (!parsed.has_value() || *parsed < NODE_ID_MIN)
+    {
+        return std::nullopt;
+    }
+    return static_cast<std::uint8_t>(*parsed);
 }
 
 /// Like promptByte but for a signed 32-bit integer (Configuration values


### PR DESCRIPTION
Makes the node console **contextual**: pick a node with the arrows, then act on it without retyping the id.

## What

`promptNodeId` now defaults to the highlighted node. The bottom-row prompt shows it as `[5]`; an empty **Enter accepts it**, and you can still type a different id. With no selection it's the plain prompt as before.

Because every node-targeted handler funnels through `promptNodeId` (29 call sites — switch on/off, all the gets, configuration, associations, wake-up, …), this single change makes them **all** operate on the selection. Also switched `handleRemoveFailedNode` and `handleSetLifeline` off the raw `promptByte` so `[f]` and `[L]` are contextual too.

## Why default-with-Enter (not a hard skip)

Keeping a (one-keystroke) prompt rather than acting instantly:
- preserves the ability to target a node that isn't selected (or before the list loads),
- keeps a confirmation beat for the destructive `[f]` (remove failed node),
- degrades cleanly when nothing is selected.

If you'd rather have a true zero-keystroke skip for the benign gets, that's an easy follow-up — say the word.

## Notes

`prompts.cpp` gains the `nodes.hpp` include for `selectedNodeId()`. Builds on both presets; 471/471 ctest unaffected (TUI has no ctest harness); clang-format + clang-tidy clean.

## Remaining #215

- auto-refresh the list on `NodeListChanged` / `NodeValueChanged` signals (today: `[r]` / add-remove for the list, ~2s poll for values);
- the DSK confirm modal (`DSKPendingConfirmation`/`ConfirmDSK`, #187).

Part of #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)