### PR TITLE
build: pass source files to clang-tidy check/fix-tidy targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,16 +176,28 @@ if(NOT CLANG_TIDY_EXE)
     set(CLANG_TIDY_EXE clang-tidy-18)  # let the target fail loudly if it's missing
 endif()
 
+# clang-tidy needs the translation units to analyse spelled out on the command
+# line (`-p <dir>` only points at the compilation database) — otherwise it exits
+# with "no input files specified". Collect the hand-written source .cpp files;
+# the generated units under ${CMAKE_BINARY_DIR}/generated/ are excluded on
+# purpose (codegen output isn't ours to lint). CONFIGURE_DEPENDS re-globs on
+# rebuild so new source files are picked up without a manual reconfigure.
+file(GLOB_RECURSE ZWAVED_TIDY_SOURCES
+    CONFIGURE_DEPENDS
+    "${CMAKE_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/utils/*.cpp"
+)
+
 # Target: fix-tidy - Fix issues with clang-tidy
 add_custom_target(fix-tidy
-    COMMAND ${CLANG_TIDY_EXE} --fix -p ${CMAKE_BINARY_DIR}
+    COMMAND ${CLANG_TIDY_EXE} --fix -p ${CMAKE_BINARY_DIR} ${ZWAVED_TIDY_SOURCES}
     COMMENT "Fixing issues with clang-tidy..."
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
 # Target: check - Check code without fixing
 add_custom_target(check
-    COMMAND ${CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
+    COMMAND ${CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR} ${ZWAVED_TIDY_SOURCES}
     COMMENT "Checking code analysis (no fixes)..."
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )


### PR DESCRIPTION
## Problem

The `check` and `fix-tidy` custom targets — documented in `CLAUDE.md` as *the* way to run static analysis — invoked clang-tidy with only `-p <builddir>` and no translation units. `-p` merely points clang-tidy at the compilation database; the source files to analyse must still be named on the command line. So every run bailed out immediately:

```
Checking code analysis (no fixes)...
Error: no input files specified.
gmake: *** [Makefile:161: check] Error 1
```

The targets have never actually linted anything.

## Fix

Glob the hand-written `src/` and `utils/` `.cpp` files (`CONFIGURE_DEPENDS` so new files are picked up on rebuild) and pass them to both targets. Generated units under the build tree stay excluded on purpose.

## Verification

After reconfigure, the generated `check` rule now feeds 95 source files to clang-tidy and actually runs the analysis (slow — clang-tidy takes minutes per TU against this codebase's templates + generated headers — but it runs rather than erroring instantly). Spot-checked files report no warnings; the tree was already clean under the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)